### PR TITLE
mvp-eng-weaponhoveroverenemy

### DIFF
--- a/Assets/FunctionalTeams/Player/Prefab/PlayerHarpoonCombined.prefab
+++ b/Assets/FunctionalTeams/Player/Prefab/PlayerHarpoonCombined.prefab
@@ -878,6 +878,12 @@ MonoBehaviour:
   _excludeLayers:
     serializedVersion: 2
     m_Bits: 8
+  _enemyOnCrosshairLayers:
+    serializedVersion: 2
+    m_Bits: 256
+  _enemyCrosshairBlockers:
+    serializedVersion: 2
+    m_Bits: 128
   _harpoonShoot: {fileID: -5070425021129914811, guid: a9035e5084fec0e4a81fdaa78201ec2c,
     type: 3}
   _harpoonFocus: {fileID: 1612608914095428297, guid: a9035e5084fec0e4a81fdaa78201ec2c,

--- a/Assets/FunctionalTeams/Player/TestGyms/PlayerHarpoonCombined.unity
+++ b/Assets/FunctionalTeams/Player/TestGyms/PlayerHarpoonCombined.unity
@@ -939,6 +939,111 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &966640054
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 966640058}
+  - component: {fileID: 966640057}
+  - component: {fileID: 966640056}
+  - component: {fileID: 966640055}
+  m_Layer: 8
+  m_Name: Cube (10)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &966640055
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 966640054}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &966640056
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 966640054}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &966640057
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 966640054}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &966640058
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 966640054}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.88, z: 6.74}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &990714071
 GameObject:
   m_ObjectHideFlags: 0
@@ -951,7 +1056,7 @@ GameObject:
   - component: {fileID: 990714074}
   - component: {fileID: 990714073}
   - component: {fileID: 990714072}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Cube (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1550,3 +1655,4 @@ SceneRoots:
   - {fileID: 962313305}
   - {fileID: 1092494163}
   - {fileID: 614082763}
+  - {fileID: 966640058}

--- a/Assets/General/Scripts/Managers/GameplayManagers/MainGameplayManagers/PlayerManager.cs
+++ b/Assets/General/Scripts/Managers/GameplayManagers/MainGameplayManagers/PlayerManager.cs
@@ -31,6 +31,9 @@ public class PlayerManager : MainGameplayManagerFramework
     private static UnityEvent _harpoonFocusMaxEvent = new();
     private static UnityEvent _harpoonFocusEndEvent = new();
 
+    private static UnityEvent _enemyOverCrosshairStartEvent = new();
+    private static UnityEvent _enemyOverCrosshairEndEvent = new();
+
     #region Base Manager
     public override void SetupInstance()
     {
@@ -90,6 +93,22 @@ public class PlayerManager : MainGameplayManagerFramework
     {
         _harpoonFocusEndEvent?.Invoke();
     }
+
+    /// <summary>
+    /// Invokes the crosshair over enemy start event
+    /// </summary>
+    public void InvokeCrosshairOverEnemyStartEvent()
+    {
+        _enemyOverCrosshairStartEvent?.Invoke();
+    }
+
+    /// <summary>
+    /// Invokes the crosshair over enemy end event
+    /// </summary>
+    public void InvokeCrosshairOverEnemyEndEvent()
+    {
+        _enemyOverCrosshairEndEvent?.Invoke();
+    }
     #endregion
 
     #region Getters
@@ -102,5 +121,7 @@ public class PlayerManager : MainGameplayManagerFramework
     public UnityEvent GetHarpoonFocusStartEvent() => _harpoonFocusStartEvent;
     public UnityEvent GetHarpoonFocusMaxEvent() => _harpoonFocusMaxEvent;
     public UnityEvent GetHarpoonFocusEndEvent() => _harpoonFocusEndEvent;
+    public UnityEvent GetEnemyOverCrosshairStartEvent() => _enemyOverCrosshairStartEvent;
+    public UnityEvent GetEnemyOverCrosshairEndEvent() => _enemyOverCrosshairEndEvent;
     #endregion
 }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -13,8 +13,8 @@ TagManager:
   - Water
   - UI
   - Grabbable
-  - 
-  - 
+  - Environment
+  - Enemy
   - 
   - 
   - 


### PR DESCRIPTION
Performs checks to see if there is currently an enemy over the player's crosshair. This can be blocked by walls. Currently just calls events for when the player starts and ends hovering over an enemy. Established so that ui/ux can adjust the crosshair in the future based on if an enemy is hovered over.