### PR TITLE
mvp-eng-harpoon-line-renderer-bug

### DIFF
--- a/Assets/FunctionalTeams/Player/Prefab/PlayerHarpoonCombined.prefab
+++ b/Assets/FunctionalTeams/Player/Prefab/PlayerHarpoonCombined.prefab
@@ -1081,9 +1081,7 @@ LineRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Positions:
-  - {x: 0, y: 0, z: 0}
-  - {x: 0, y: 0, z: 1}
+  m_Positions: []
   m_Parameters:
     serializedVersion: 3
     widthMultiplier: 0.05


### PR DESCRIPTION
The harpoon rope was visible in the environment before being fired. The harpoon would set the amount of vertices when fired and when fully retracted. Problem being it started in the environment with 2 vertices, as is standard with line renderers. This meant you could see the line sitting at 0,0,0 in the world before being fired.