### PR TITLE
mvp-eng-reworkedharpoonreel

### DIFF
--- a/Assets/FunctionalTeams/Player/Prefab/PlayerHarpoonCombined.prefab
+++ b/Assets/FunctionalTeams/Player/Prefab/PlayerHarpoonCombined.prefab
@@ -840,8 +840,8 @@ MonoBehaviour:
   _harpoonPrefab: {fileID: 8430130115990038482, guid: 84f2eb355931fc747b5e9353cbff9bbb,
     type: 3}
   _harpoonSpeed: 30
+  _reelSpeed: 30
   _maxDistance: 100
-  _reelDuration: 3
   _gunCooldown: 2
   _holdToRetractMode: 0
   _focusTime: 2

--- a/Assets/FunctionalTeams/Player/Scripts/Harpoon/HarpoonGun.cs
+++ b/Assets/FunctionalTeams/Player/Scripts/Harpoon/HarpoonGun.cs
@@ -17,15 +17,14 @@ public class HarpoonGun : MonoBehaviour
     [SerializeField] private GameObject _harpoonPrefab; // Prefab of the harpoon
     [Tooltip("The speed the harpoon moves in the launch direction")]
     [SerializeField] private float _harpoonSpeed = 50f; // Speed of the harpoon
+    [Tooltip("The speed the harpoon projectile moves back towards the player")]
+    [SerializeField] private float _reelSpeed;
     [Tooltip("max distance the harpoon can launch")]
     [SerializeField] private float _maxDistance = 100f; // Max travel distance
-    [Tooltip("the max duration the harpoon can take to reel in(at max distance)")]
-    [SerializeField] private float _reelDuration = 3f; // Time to reel in at max distance
     [Tooltip("cooldown of the gun after fully reeled in")]
     [SerializeField] private float _gunCooldown = 2f; // cd of harpoon gun after fully retracted
     [Tooltip("if true then you have to hold mouse down to retract fully. if false retracts automatically")]
     [SerializeField] private bool _holdToRetractMode = true; // turns on or off having to hold mouse down to retract
-
     [Space]
     [Tooltip("The time it takes to reach max focus")]
     [SerializeField] private float _focusTime;
@@ -82,7 +81,7 @@ public class HarpoonGun : MonoBehaviour
     private Coroutine _focusingCoroutine;
     private float _currentFocus = 0;
     private RaycastHit _hit;
-    private float _currentReelDur;
+    //private float _currentReelDur;
     private HarpoonRope _harpoonRope;
     private Coroutine _enemyCrosshairChecksCoroutine;
 
@@ -259,17 +258,6 @@ public class HarpoonGun : MonoBehaviour
     private void StartReeling(Vector3 _hitPosition)
     {
         _isReeling = true;
-        
-        float distanceFromPlayer;
-        if(_hit.transform != null)
-        {
-            distanceFromPlayer = Vector3.Distance(transform.position, _hitPosition);
-        }else
-        {
-            distanceFromPlayer = _maxDistance;
-        }
-        // Adjust the reeling time based on the distance
-        _currentReelDur = distanceFromPlayer / _maxDistance * _reelDuration;
         StartCoroutine(ReelHarpoon());
     }
 
@@ -293,7 +281,7 @@ public class HarpoonGun : MonoBehaviour
         // Lerp the harpoon back to the player over time
         var startPos = _harpoonSpear.transform.position;
         bool startedRetracting = false;
-        while(elapsedTime < _currentReelDur)
+        while (Vector3.Distance(transform.position, _harpoonSpear.transform.position) > .1f)
         {
             //if hold to retract is on, only pull in harpoon if holding down button
             if(_holdToRetractMode)
@@ -311,7 +299,8 @@ public class HarpoonGun : MonoBehaviour
                     }
                     _isShooting = true;
                     _harpoonSpear.transform.GetChild(0).LookAt(_harpoonTip);
-                    _harpoonSpear.transform.position = Vector3.Lerp(startPos, _harpoonTip.position, elapsedTime/ _currentReelDur);
+                    HarpoonReelProjectileMovement();
+                    //_harpoonSpear.transform.position = Vector3.Lerp(startPos, _harpoonTip.position, elapsedTime/ _currentReelDur);
                     elapsedTime+= Time.deltaTime;
                 } 
                 //otherwise automatically pull in 
@@ -319,7 +308,8 @@ public class HarpoonGun : MonoBehaviour
             else
             {
                 _harpoonSpear.transform.GetChild(0).LookAt(_harpoonTip);
-                _harpoonSpear.transform.position = Vector3.Lerp(startPos, _harpoonTip.position, elapsedTime/ _currentReelDur);
+                HarpoonReelProjectileMovement();
+                //_harpoonSpear.transform.position = Vector3.Lerp(startPos, _harpoonTip.position, elapsedTime/ _currentReelDur);
                 elapsedTime+= Time.deltaTime; 
             }
             yield return null;
@@ -337,6 +327,15 @@ public class HarpoonGun : MonoBehaviour
         StartCoroutine(ResetHarpoon());
 
         PlayerManager.Instance.InvokeHarpoonRetractEvent();
+    }
+
+    /// <summary>
+    /// Moves the harpoon projectile back to the player
+    /// </summary>
+    private void HarpoonReelProjectileMovement()
+    {
+        Vector3 direction = (transform.position - _harpoonSpear.transform.position).normalized;
+        _harpoonSpear.transform.position += direction * Time.deltaTime*_reelSpeed;
     }
 
     /// <summary>

--- a/Assets/General/Prefabs/Harpoon.prefab
+++ b/Assets/General/Prefabs/Harpoon.prefab
@@ -101,7 +101,7 @@ BoxCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
@@ -130,7 +130,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 0
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0


### PR DESCRIPTION
Previously when retracting the harpoon it worked on a Lerp. That would be fine if the player never moved. But if you reel partially, then move the player before reeling again, the midpoint between the player and harpoon end location has changed a lot so the harpoon teleports. Now the harpoon just moves towards the player. Simpler and without the issues