### PR TITLE
lb-eng-vfx-system-can-play-animations-lv-317

### DIFF
--- a/Assets/General/Scripts/Health/GeneralVfxFunctionality.cs
+++ b/Assets/General/Scripts/Health/GeneralVfxFunctionality.cs
@@ -13,7 +13,13 @@ using UnityEngine;
 /// </summary>
 public class GeneralVfxFunctionality : MonoBehaviour
 {
+    [Tooltip("All vfx to play when activated")]
     private ParticleSystem[] _particleSystems;
+    [Tooltip("All animations to play with an associated vfx if it has any")]
+    private Animator[] _vfxAnimators;
+
+    [Tooltip("The animation trigger used for all vfx animations")]
+    private const string VFX_ANIMATION_TRIGGER = "PlayVfxAnim";
 
     /// <summary>
     /// Adds all particle systems attached to this to a list
@@ -21,6 +27,7 @@ public class GeneralVfxFunctionality : MonoBehaviour
     public void SetupChildParticleSystems()
     {
         _particleSystems = GetComponentsInChildren<ParticleSystem>();
+        _vfxAnimators = GetComponentsInChildren<Animator>();
     }
 
     /// <summary>
@@ -28,9 +35,15 @@ public class GeneralVfxFunctionality : MonoBehaviour
     /// </summary>
     public void StartAllVfx()
     {
+        //Play all vfx
         foreach (ParticleSystem particleSystem in _particleSystems)
         {
             particleSystem.Play();
+        }
+        //Play all animations
+        foreach (Animator animator in _vfxAnimators)
+        {
+            animator.SetTrigger(VFX_ANIMATION_TRIGGER);
         }
     }
 


### PR DESCRIPTION
I was asked to have functionality for vfx to play animations if they have any. This provides that functionality. I will update the documentation accordingly. Only restriction is that all vfx animation triggers must share a name. Could alternatively be done by creating a class containing animation and an associated trigger. But I'm trying to avoid making things editor accessible if possible

https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?selectedIssue=LV-317 