### PR TITLE
vs-eng-implement-gameplay-scene-loaded-event-functionality

### DIFF
--- a/Assets/General/Scripts/Managers/AbstractManagers/MainManagers/MainUniversalManagerFramework.cs
+++ b/Assets/General/Scripts/Managers/AbstractManagers/MainManagers/MainUniversalManagerFramework.cs
@@ -6,31 +6,57 @@
 // Description:     Provides the framework to be used by all main universal managers
 ******************************************************************************/
 
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
 /// <summary>
 /// Provides the framework for the main universal managers
 /// Since Universal and Gameplay managers are pretty similar at the moment there isn't much here
 /// </summary>
 public class MainUniversalManagerFramework : MainManagerFramework
 {
+    /// <summary>
+    /// Establishes the instance for the manager
+    /// </summary>
     public override void SetupInstance()
     {
 
     }
 
+    /// <summary>
+    /// Performs any needed setup for the manager
+    /// </summary>
     public override void SetupMainManager()
     {
         SubscribeToEvents();
     }
+
+    /// <summary>
+    /// Subscribes to any universal events
+    /// </summary>
     protected override void SubscribeToEvents()
+    {
+        SceneLoadingManager.Instance.GetGameplaySceneLoaded().AddListener(SubscribeToGameplayEvents);
+    }
+
+    /// <summary>
+    /// Subscribes to events exclusive to the gameplay scenes
+    /// Used for subscribing to any GameplayManager events
+    /// </summary>
+    protected virtual void SubscribeToGameplayEvents()
     {
 
     }
 
+    /// <summary>
+    /// Unsubscribes from any universal events
+    /// </summary>
     protected override void UnsubscribeToEvents()
+    {
+        SceneLoadingManager.Instance.GetGameplaySceneLoaded().RemoveListener(SubscribeToGameplayEvents);
+    }
+
+    /// <summary>
+    /// Unsubscribes to events exclusive to gameplay scenes
+    /// </summary>
+    protected virtual void UnsubscribeToGameplayEvents()
     {
 
     }

--- a/Assets/General/Scripts/Managers/GameplayManagers/GameplayManagers.cs
+++ b/Assets/General/Scripts/Managers/GameplayManagers/GameplayManagers.cs
@@ -60,7 +60,7 @@ public class GameplayManagers : CoreManagersFramework
             mainManager.SetupMainManager();
         }
 
-        SceneLoadingManager.Instance.InvokeGameplaySceneLoaded();
+        SceneLoadingManager.Instance.InvokeOnGameplaySceneLoaded();
     }
 
     #region Getters

--- a/Assets/General/Scripts/Managers/UniversalManagers/MainUniversalManagers/AmbienceManager.cs
+++ b/Assets/General/Scripts/Managers/UniversalManagers/MainUniversalManagers/AmbienceManager.cs
@@ -48,7 +48,7 @@ public class AmbienceManager : AudioManager
     protected override void SubscribeToEvents()
     {
         base.SubscribeToEvents();
-        SceneLoadingManager.Instance.GetSceneChangedEvent.AddListener(StartBackgroundAudio);
+        SceneLoadingManager.Instance.GetOnSceneChangedEvent().AddListener(StartBackgroundAudio);
     }
 
     /// <summary>

--- a/Assets/General/Scripts/Managers/UniversalManagers/MainUniversalManagers/SceneLoadingManager.cs
+++ b/Assets/General/Scripts/Managers/UniversalManagers/MainUniversalManagers/SceneLoadingManager.cs
@@ -29,26 +29,16 @@ public class SceneLoadingManager : MainUniversalManagerFramework
     public static SceneLoadingManager Instance;
 
     //Occurs when the currently active scene is changed
-    private UnityEvent _sceneChangedEvent = new();
-    private UnityEvent _gameplaySceneLoaded = new();
+    private UnityEvent _onSceneChangedEvent = new();
+    private UnityEvent _onGameplaySceneLoaded = new();
 
-    private UnityEvent _additiveLoadAddedEvent = new();
-    private UnityEvent _additiveLoadRemovedEvent = new();
+    private UnityEvent _onAdditiveLoadAddedEvent = new();
+    private UnityEvent _onAdditiveLoadRemovedEvent = new();
 
     private void Awake()
     {
         SetupInstance();
         SubscribeToEvents();
-    }
-
-    protected override void SubscribeToEvents()
-    {
-        _gameplaySceneLoaded.AddListener(SubscribeToGameplayEvents);
-    }
-
-    protected void SubscribeToGameplayEvents()
-    {
-        PlayerManager.Instance.GetOnPlayerDeath().AddListener(LoadDeathScreen);
     }
 
     /// <summary>
@@ -107,7 +97,7 @@ public class SceneLoadingManager : MainUniversalManagerFramework
             yield return null;
         }
 
-        InvokeSceneChangedEvent();
+        InvokeOnSceneChangedEvent();
 
         //Can start the ending scene transition animation here
         //Will be implemented when scene transition work occurs
@@ -124,7 +114,7 @@ public class SceneLoadingManager : MainUniversalManagerFramework
     {
         SceneManager.LoadScene(sceneID, LoadSceneMode.Additive);
 
-        InvokeSceneAdditiveLoadAddEvent();
+        InvokeOnSceneAdditiveLoadAddEvent();
     }
 
     /// <summary>
@@ -135,7 +125,7 @@ public class SceneLoadingManager : MainUniversalManagerFramework
     {
         SceneManager.UnloadSceneAsync(sceneID);
 
-        InvokeSceneAdditiveLoadRemoveEvent();
+        InvokeOnSceneAdditiveLoadRemoveEvent();
     }
 
     #region Base Manager
@@ -153,38 +143,69 @@ public class SceneLoadingManager : MainUniversalManagerFramework
     protected override void OnDestroy()
     {
         base.OnDestroy();
-        _gameplaySceneLoaded.RemoveListener(SubscribeToGameplayEvents);
+    }
+
+    protected override void SubscribeToEvents()
+    {
+        base.SubscribeToEvents();
+    }
+
+    /// <summary>
+    /// Subscribes to all events relating to gameplay
+    /// This is only called when loading into a scene with Gameplay Managers in it
+    /// Subscribes to events that come from gameplay manager
+    /// </summary>
+    protected override void SubscribeToGameplayEvents()
+    {
+        base.SubscribeToGameplayEvents();
+        PlayerManager.Instance.GetOnPlayerDeath().AddListener(LoadDeathScreen);
     }
     #endregion
 
     #region Events
-    private void InvokeSceneChangedEvent()
+    /// <summary>
+    /// Invokes event associated with loading a new scene
+    /// </summary>
+    private void InvokeOnSceneChangedEvent()
     {
-        _sceneChangedEvent?.Invoke();
+        _onSceneChangedEvent?.Invoke();
     }
 
-    public void InvokeGameplaySceneLoaded()
+    /// <summary>
+    /// Invokes event associated with loading a gameplay scene
+    /// Gameplay scenes are any scenes containing gameplay managers
+    /// </summary>
+    public void InvokeOnGameplaySceneLoaded()
     {
-        _gameplaySceneLoaded?.Invoke();
+        _onGameplaySceneLoaded?.Invoke();
     }
 
-    private void InvokeSceneAdditiveLoadAddEvent()
+    /// <summary>
+    /// Invokes event associated with adding an additively loaded scene
+    /// </summary>
+    private void InvokeOnSceneAdditiveLoadAddEvent()
     {
-        _additiveLoadAddedEvent?.Invoke();
+        _onAdditiveLoadAddedEvent?.Invoke();
     }
 
-    private void InvokeSceneAdditiveLoadRemoveEvent()
+    /// <summary>
+    /// Invokes event associated with removing an additively loaded scene
+    /// </summary>
+    private void InvokeOnSceneAdditiveLoadRemoveEvent()
     {
-        _additiveLoadRemovedEvent?.Invoke();
+        _onAdditiveLoadRemovedEvent?.Invoke();
     }
 
     #endregion
 
     #region Getters
 
-    public UnityEvent GetSceneChangedEvent => _sceneChangedEvent;
+    public UnityEvent GetOnSceneChangedEvent() => _onSceneChangedEvent;
 
-    public UnityEvent GetGameplaySceneLoaded => _gameplaySceneLoaded;
+    public UnityEvent GetGameplaySceneLoaded() => _onGameplaySceneLoaded;
+
+    public UnityEvent GetOnAdditiveSceneAdded() => _onAdditiveLoadAddedEvent;
+    public UnityEvent GetOnAdditiveSceneRemoved() => _onAdditiveLoadRemovedEvent;
 
     #endregion
 }


### PR DESCRIPTION
Subscribes all universal managers to a virtual function for subscribing to gameplay events. Previously it was annoying for universal managers to subscribe to gameplay managers events as it couldn't do so through start/awake/onenable because that wouldn't work if you started on a non gameplay scene. Also added some comments and renamed some events to fit naming conventions