### PR TITLE
vs-eng-Procedural-tentacles-attach-to-player-LV-636

### DIFF
--- a/Assets/GameAssets/Boss/BossScripts/Attacks/Lockdown/LockdownAttackEnemyController.cs
+++ b/Assets/GameAssets/Boss/BossScripts/Attacks/Lockdown/LockdownAttackEnemyController.cs
@@ -59,8 +59,8 @@ public class LockdownAttackEnemyController : MonoBehaviour
     /// <summary>
     /// Establishes all variables for the enemy controller
     /// </summary>
-    /// <param name="patrolEnemy"></param>
-    /// <param name="coreEnemy"></param>
+    /// <param name="patrolEnemy"> The patrol enemy to spawn </param>
+    /// <param name="coreEnemy"> The core enemy to spawn </param>
     public void SetUpEnemyController(GameObject patrolEnemy, GameObject coreEnemy)
     {
         _patrolEnemyPrefab = patrolEnemy;
@@ -102,7 +102,8 @@ public class LockdownAttackEnemyController : MonoBehaviour
     private void SpawnPatrolEnemy()
     {
         _instantiatedPatrolEnemy =
-            Instantiate(_patrolEnemyPrefab, _patrolLocation.PatrolSpawnPoint.position, Quaternion.identity,transform);
+            Instantiate(_patrolEnemyPrefab, _patrolLocation.PatrolSpawnPoint.position, 
+            Quaternion.identity,transform.parent);
 
         //Gets the patrol enemy behavior off of the patrol enemy
         if (!_instantiatedPatrolEnemy.TryGetComponent(out LockdownAttackPatrolEnemyBehavior patrolEnemyBehavior))
@@ -121,7 +122,8 @@ public class LockdownAttackEnemyController : MonoBehaviour
     {
         //Spawns the core
         _instantiatedCoreEnemy = 
-            Instantiate(_coreEnemyPrefab, _patrolLocation.CoreSpawnPoint.position, Quaternion.identity,transform);
+            Instantiate(_coreEnemyPrefab, _patrolLocation.CoreSpawnPoint.position, 
+            Quaternion.identity,transform.parent);
         AmbienceManager.APlayAmbienceOnObject?.Invoke(FmodAmbienceEvents.Instance.LimbIdle, _instantiatedCoreEnemy);
         RuntimeSfxManager.APlayOneShotSfx?.Invoke(FmodSfxEvents.Instance.LimbSpawn, _patrolLocation.CoreSpawnPoint.position);
 

--- a/Assets/GameAssets/Boss/BossScripts/Attacks/Lockdown/LockdownAttackPatrolEnemyBehavior.cs
+++ b/Assets/GameAssets/Boss/BossScripts/Attacks/Lockdown/LockdownAttackPatrolEnemyBehavior.cs
@@ -56,12 +56,10 @@ public class LockdownAttackPatrolEnemyBehavior : MonoBehaviour
         BeginPatrolling();
         InitializePlayerTransform();
 
+        Transform proceduralAnimationObject = _patrolLocationData.EnemyRoom.gameObject.transform.GetChild(3).transform;
 
-        // child 4 is the rooms vine, set it active
-        transform.parent.GetChild(3).gameObject.SetActive(true);
-
-        //set ik target of vine to be the patrol transform (this), child 3 of the room should be the parent of the IK
-        transform.parent.GetChild(3).GetComponentInChildren<FastIKFabric>().Target = transform;
+        proceduralAnimationObject.gameObject.SetActive(true);
+        proceduralAnimationObject.GetComponentInChildren<FastIKFabric>().Target = transform;
     }
 
     /// <summary>


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?assignee=6318bb796856bdd60aa045de&selectedIssue=LV-636

Reason why is that the enemy was childed to the room, and so when the room was checking for if the player enetered the room it was taking into account both the room collider and the enemy collider. So it would increase the collision counter by 2 rather than 1. Had to make some minor adjustments to the enemy behavior to make that work. The enemy is now a child of the attack rather than the room