### PR TITLE
White Reticle: LV-649

### DIFF
--- a/Assets/General/Prefabs/PlayerHUDCanvas.prefab
+++ b/Assets/General/Prefabs/PlayerHUDCanvas.prefab
@@ -4581,7 +4581,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.039215688}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1


### PR DESCRIPTION
Jira: https://bradleycapstone.atlassian.net/browse/LV-649?atlOrigin=eyJpIjoiNDJkYmY0YzZiOTRhNDlhOGE4MGFhYjM3Yjk5OWE2ZDAiLCJwIjoiaiJ9

All I did was change the in-scene reticle scope opacity to match the unfocused reticle opacity. Fully seems to fix the issue. 

original bug was the reticle appearing as white at the start of the scene, and when restarting the game.