### PR TITLE
vs-eng-two-attacks-die-LV-642

### DIFF
--- a/Assets/GameAssets/Boss/BossScripts/Attacks/Lockdown/LockdownAttackEnemyController.cs
+++ b/Assets/GameAssets/Boss/BossScripts/Attacks/Lockdown/LockdownAttackEnemyController.cs
@@ -143,8 +143,8 @@ public class LockdownAttackEnemyController : MonoBehaviour
     private void CoreDestroyed(WeakPointHandler handler)
     {
         //Invokes event for core destruction and removes its listeners
-        InvokeOnCoreDestroyed();
         ForceDestroy();
+        InvokeOnCoreDestroyed();
     }
 
     /// <summary>
@@ -153,7 +153,7 @@ public class LockdownAttackEnemyController : MonoBehaviour
     public void ForceDestroy()
     {
         //Destroys the patrol enemy and core
-        Destroy(_instantiatedPatrolEnemy);
+        _instantiatedPatrolEnemy.GetComponent<LockdownAttackPatrolEnemyBehavior>().DestroyEnemy();
         Destroy(_instantiatedCoreEnemy);
 
         _onCoreDestroyed.RemoveAllListeners();

--- a/Assets/GameAssets/Boss/BossScripts/Attacks/Lockdown/LockdownAttackPatrolEnemyBehavior.cs
+++ b/Assets/GameAssets/Boss/BossScripts/Attacks/Lockdown/LockdownAttackPatrolEnemyBehavior.cs
@@ -25,9 +25,6 @@ public class LockdownAttackPatrolEnemyBehavior : MonoBehaviour
     [Tooltip("Speed at which enemy chases the player")]
     [SerializeField] private float _seekPlayerSpeed = 5f;
 
-    [Tooltip("How long the enemy patrols before despawning")]
-    [SerializeField] private float _attackDuration = 15f;
-
     [Tooltip("Adds a delay before starting to patrol the room")]
     [SerializeField] private float _timeToWaitBeforePatroling = .5f;
 
@@ -38,7 +35,7 @@ public class LockdownAttackPatrolEnemyBehavior : MonoBehaviour
     /// </summary>
     private Transform _targetPoint;
     
-    private bool _isPlayerInAttackRange = false;
+    private bool _isPlayerInAttackRange;
     private int _currentTargetIndex;
 
     private PatrolLocation _patrolLocationData;

--- a/Assets/GameAssets/Boss/BossScripts/Attacks/Lockdown/LockdownAttackPatrolEnemyBehavior.cs
+++ b/Assets/GameAssets/Boss/BossScripts/Attacks/Lockdown/LockdownAttackPatrolEnemyBehavior.cs
@@ -43,6 +43,8 @@ public class LockdownAttackPatrolEnemyBehavior : MonoBehaviour
 
     private PatrolLocation _patrolLocationData;
 
+    private GameObject _proceduralAnimationObject;
+
     private Transform _playerTransform;
     private Coroutine _patrolCoroutine;
 
@@ -56,10 +58,10 @@ public class LockdownAttackPatrolEnemyBehavior : MonoBehaviour
         BeginPatrolling();
         InitializePlayerTransform();
 
-        Transform proceduralAnimationObject = _patrolLocationData.EnemyRoom.gameObject.transform.GetChild(3).transform;
+        _proceduralAnimationObject = _patrolLocationData.EnemyRoom.gameObject.transform.GetChild(3).gameObject;
 
-        proceduralAnimationObject.gameObject.SetActive(true);
-        proceduralAnimationObject.GetComponentInChildren<FastIKFabric>().Target = transform;
+        _proceduralAnimationObject.SetActive(true);
+        _proceduralAnimationObject.GetComponentInChildren<FastIKFabric>().Target = transform;
     }
 
     /// <summary>
@@ -158,12 +160,12 @@ public class LockdownAttackPatrolEnemyBehavior : MonoBehaviour
     /// <summary>
     /// Notifies that patrol enemy has died and destroys self
     /// </summary>
-    private void DestroyEnemy()
+    public void DestroyEnemy()
     {
-        
         // Destroys enemy
-        if (gameObject != null)
+        if (gameObject != null && _proceduralAnimationObject != null)
         {
+            Destroy(_proceduralAnimationObject);
             Destroy(gameObject);
         }
     }

--- a/Assets/GameAssets/Boss/BossScripts/WeakPoints/WeakPointHandler.cs
+++ b/Assets/GameAssets/Boss/BossScripts/WeakPoints/WeakPointHandler.cs
@@ -178,9 +178,8 @@ public class WeakPointHandler : MonoBehaviour
     private void MaxWeakPointsDestroyed()
     {
         InvokeAllWeakPointsDestroyedEvent();
-        RuntimeSfxManager.APlayOneShotSfx?.Invoke(FmodSfxEvents.Instance.LimbDestroyed, _parentGameObject.transform.position);
-
-        Destroy(_parentGameObject);
+        RuntimeSfxManager.APlayOneShotSfx?.Invoke(FmodSfxEvents.Instance.LimbDestroyed, 
+            _parentGameObject.transform.position);
     }
 
     #endregion

--- a/Assets/General/Scripts/Managers/UniversalManagers/MainUniversalManagers/RuntimeSfxManager.cs
+++ b/Assets/General/Scripts/Managers/UniversalManagers/MainUniversalManagers/RuntimeSfxManager.cs
@@ -103,7 +103,7 @@ public class RuntimeSfxManager : AudioManager
     {
         if (eventReference.IsNull)
         {
-            Debug.LogWarning(eventReference + " is null.");
+            Debug.LogWarning("FMOD Event is null - make sure it's assigned in the Audio Manager");
             return;
         }
 

--- a/Assets/General/Scripts/Managers/UniversalManagers/MainUniversalManagers/RuntimeSfxManager.cs
+++ b/Assets/General/Scripts/Managers/UniversalManagers/MainUniversalManagers/RuntimeSfxManager.cs
@@ -103,7 +103,7 @@ public class RuntimeSfxManager : AudioManager
     {
         if (eventReference.IsNull)
         {
-            Debug.LogWarning("FMOD Event is null - make sure it's assigned in the Audio Manager");
+            Debug.LogWarning("FMOD Event is null. Make sure it's assigned in the Audio Manager!");
             return;
         }
 


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?assignee=6318bb796856bdd60aa045de&selectedIssue=LV-642
Fixed the issue with both attacks dying. The weak point handler destroyed its owner after all weak points are destroyed. It probably shouldn't have done that in the first place. That presented another issue. Fixed that one. Personally not a fan of the relationship the procedural animation object has to the rest of the attack, feels a little odd but I'm sticking with it