### PR TITLE
LV-949-Monster-doesn-t-attack-after-first-ineraction

### DIFF
--- a/Assets/GameAssets/Boss/BossScripts/Attacks/ProceduralAttack/ProceduralVine.cs
+++ b/Assets/GameAssets/Boss/BossScripts/Attacks/ProceduralAttack/ProceduralVine.cs
@@ -38,6 +38,11 @@ public class ProceduralVine : MonoBehaviour
     [SerializeField] private float _lungeToPlayerDuration = .2f;
     [SerializeField] private float _moveBackAfterAttackTime = 2f;
 
+    [Header("Attack CD")]
+    [Tooltip("after the vine gets back to the path post attacking this is how long it waits before triggers another")]
+    [SerializeField] private float cdToAttackAfterMoveBackToPath = .2f; // after the vine gets back to the path post attacking this is how long it waits before triggers another
+    private float currentAttackCD;
+
     [Header("Retract stuff")]
     [SerializeField] private PathCreator _retractPath; // The target to move toward
     [SerializeField] private Transform _baseOfVine;
@@ -59,12 +64,16 @@ public class ProceduralVine : MonoBehaviour
     /// </summary>
     private void Update() 
     {
-        if(!_isAttacking)
         if(!_isAttacking && !_isRetracting)
         {
             //move along path
             MoveAlongPath();
+            if(currentAttackCD > 0)
+            {
+               currentAttackCD -= Time.deltaTime; 
+            }    
         }
+
         if(_isRetracting && _retractPath.path.length > _retractDistance)
         {
             Retracting();
@@ -126,6 +135,7 @@ public class ProceduralVine : MonoBehaviour
     private IEnumerator Attack(Vector3 playerPosition)
     {
         _isAttacking = true;
+        currentAttackCD = cdToAttackAfterMoveBackToPath;
         StopMovementAudio();
 
         // Calculate the direction from the current object to the target object (X and Z only)
@@ -163,9 +173,9 @@ public class ProceduralVine : MonoBehaviour
     /// the original way we detected if the player was entering the room
     /// </summary>
     /// <param name="collider"></param>
-    private void OnTriggerEnter(Collider collider)
+    private void OnTriggerStay(Collider collider)
     {
-        if(IsColliderPlayer(collider) && !_isAttacking)
+        if(IsColliderPlayer(collider) && !_isAttacking && currentAttackCD <= 0)
         {
             //start attack
             StartCoroutine(Attack(collider.transform.position));

--- a/Assets/GameAssets/Boss/BossScripts/Attacks/ProceduralAttack/ProceduralVine.cs
+++ b/Assets/GameAssets/Boss/BossScripts/Attacks/ProceduralAttack/ProceduralVine.cs
@@ -40,8 +40,8 @@ public class ProceduralVine : MonoBehaviour
 
     [Header("Attack CD")]
     [Tooltip("after the vine gets back to the path post attacking this is how long it waits before triggers another")]
-    [SerializeField] private float cdToAttackAfterMoveBackToPath = .2f; // after the vine gets back to the path post attacking this is how long it waits before triggers another
-    private float currentAttackCD;
+    [SerializeField] private float _cooldownToAttackAfterMoveBackToPath = .2f; // after the vine gets back to the path post attacking this is how long it waits before triggers another
+    private float _currentAttackCD;
 
     [Header("Retract stuff")]
     [SerializeField] private PathCreator _retractPath; // The target to move toward
@@ -68,9 +68,9 @@ public class ProceduralVine : MonoBehaviour
         {
             //move along path
             MoveAlongPath();
-            if(currentAttackCD > 0)
+            if(_currentAttackCD > 0)
             {
-               currentAttackCD -= Time.deltaTime; 
+               _currentAttackCD -= Time.deltaTime; 
             }    
         }
 
@@ -135,7 +135,7 @@ public class ProceduralVine : MonoBehaviour
     private IEnumerator Attack(Vector3 playerPosition)
     {
         _isAttacking = true;
-        currentAttackCD = cdToAttackAfterMoveBackToPath;
+        _currentAttackCD = _cooldownToAttackAfterMoveBackToPath;
         StopMovementAudio();
 
         // Calculate the direction from the current object to the target object (X and Z only)
@@ -175,7 +175,7 @@ public class ProceduralVine : MonoBehaviour
     /// <param name="collider"></param>
     private void OnTriggerStay(Collider collider)
     {
-        if(IsColliderPlayer(collider) && !_isAttacking && currentAttackCD <= 0)
+        if(IsColliderPlayer(collider) && !_isAttacking && _currentAttackCD <= 0)
         {
             //start attack
             StartCoroutine(Attack(collider.transform.position));


### PR DESCRIPTION
I changed the attack to triggerOnStay instead of OnEnter. It now has a cooldown after it resets from attacking which is currently only .2f before it attacks again. Viewable in scene "ProceduralTest"