### PR TITLE
alpha-eng-Harpoon-reload-audio-is-delayed-LV-939

### DIFF
--- a/Assets/GameAssets/Player/PlayerPrefabs/Harpoon.prefab
+++ b/Assets/GameAssets/Player/PlayerPrefabs/Harpoon.prefab
@@ -508,6 +508,7 @@ MonoBehaviour:
     type: 3}
   _recoilCameraShakeIntensity: 5
   _recoilCameraShakeTime: 0.05
+  _reloadAudioDelay: 1.65
 --- !u!95 &747847874638984372
 Animator:
   serializedVersion: 5

--- a/Assets/GameAssets/Player/PlayerScripts/Harpoon/HarpoonGun.cs
+++ b/Assets/GameAssets/Player/PlayerScripts/Harpoon/HarpoonGun.cs
@@ -14,6 +14,7 @@ using UnityEngine.InputSystem;
 using UnityEngine.Serialization;
 using Cinemachine;
 using Unity.VisualScripting;
+using PrimeTween;
 
 /// <summary>
 /// Provides the functionality for the harpoon weapon
@@ -109,6 +110,10 @@ public class HarpoonGun : MonoBehaviour
     [SerializeField] private float _recoilCameraShakeIntensity = 5f;
     [Tooltip("Recoil time Shake")]
     [SerializeField] private float _recoilCameraShakeTime = 0.05f;
+
+    [Space]
+    [Header("Other")]
+    [SerializeField] private float _reloadAudioDelay;
 
     public static HarpoonGun Instance;
 
@@ -282,6 +287,8 @@ public class HarpoonGun : MonoBehaviour
 
             PlayerManager.Instance.InvokeOnHarpoonStartReloadEvent();
 
+            Tween.Delay(this, _reloadAudioDelay, PlayReloadAudio);
+
             float reloadTimeRemaining = _reloadTime;
             while (reloadTimeRemaining > 0)
             {
@@ -306,6 +313,15 @@ public class HarpoonGun : MonoBehaviour
     }
 
     /// <summary>
+    /// Plays the audio associated with the reload
+    /// </summary>
+    private void PlayReloadAudio()
+    {
+        RuntimeSfxManager.APlayOneShotSfx?
+            .Invoke(FmodSfxEvents.Instance.HarpoonReload, gameObject.transform.position);
+    }
+
+    /// <summary>
     /// increments reserve ammo to an acceptable state to enter
     /// infinite ammo mode
     /// </summary>
@@ -326,8 +342,6 @@ public class HarpoonGun : MonoBehaviour
     {
         _harpoonFiringState = EHarpoonFiringState.Ready;
         _harpoonOnGun.SetActive(true);
-        RuntimeSfxManager.APlayOneShotSfx?
-            .Invoke(FmodSfxEvents.Instance.HarpoonReload, gameObject.transform.position);
 
         if (_isFocusButtonHeld)
         {


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?customFilter=ari%3Acloud%3Ajira-software%3A792ff6f6-f5ba-4734-a1cd-457d34518a06%3Acustom-filter%2Factivation%2F489b3b11-a1a5-4c9e-afed-c8d621aa5e68%2F32%2F0ffdcf80-e13c-47e4-8c44-6b732fc8693c&selectedIssue=LV-939

The reload sfx used to play on the completion of the reload. Now it plays after a set duration after the reload start. Pretty simple