### PR TITLE
Mouse does not appear in pause menu-931

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -79,7 +79,7 @@ PlayerSettings:
   androidAutoRotationBehavior: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
-  runInBackground: 0
+  runInBackground: 1
   captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0


### PR DESCRIPTION
checked "run in background" in build settings. I could not replicate the bug as described, even when testing extensively in build, but my research indicates this might be a potential fix.