### PR TITLE
alpha-eng-Monster-Hitbox-Inconsistency-LV-961

### DIFF
--- a/Assets/GameAssets/Boss/BossPrefabs/WeakPoints/WeakPoint.prefab
+++ b/Assets/GameAssets/Boss/BossPrefabs/WeakPoints/WeakPoint.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 6642669769206943224}
   - component: {fileID: 7038937634937232616}
   - component: {fileID: 2121949755945095394}
-  - component: {fileID: 6122806561773992166}
+  - component: {fileID: -27814061537787058}
   m_Layer: 8
   m_Name: WeakPoint
   m_TagString: Enemy
@@ -58,9 +58,9 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 0
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 0
-  m_Constraints: 0
+  m_Constraints: 126
   m_CollisionDetection: 2
 --- !u!114 &7038937634937232616
 MonoBehaviour:
@@ -87,8 +87,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _maxHealth: 1
---- !u!135 &6122806561773992166
-SphereCollider:
+--- !u!65 &-27814061537787058
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -102,9 +102,9 @@ SphereCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Radius: 1.2
+  m_Size: {x: 1.2, y: 1.2, z: 1.2}
   m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/GameAssets/Boss/BossPrefabs/WeakPoints/WeakPoint.prefab
+++ b/Assets/GameAssets/Boss/BossPrefabs/WeakPoints/WeakPoint.prefab
@@ -61,7 +61,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
-  m_CollisionDetection: 0
+  m_CollisionDetection: 2
 --- !u!114 &7038937634937232616
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -106,5 +106,5 @@ SphereCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Radius: 0.8
+  m_Radius: 1.2
   m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/GameAssets/Player/PlayerPrefabs/HarpoonProjectile.prefab
+++ b/Assets/GameAssets/Player/PlayerPrefabs/HarpoonProjectile.prefab
@@ -83,7 +83,7 @@ Rigidbody:
   m_IsKinematic: 1
   m_Interpolate: 0
   m_Constraints: 0
-  m_CollisionDetection: 1
+  m_CollisionDetection: 2
 --- !u!114 &7998368123337484348
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/TimeManager.asset
+++ b/ProjectSettings/TimeManager.asset
@@ -3,7 +3,7 @@
 --- !u!5 &1
 TimeManager:
   m_ObjectHideFlags: 0
-  Fixed Timestep: 0.02
+  Fixed Timestep: 0.01
   Maximum Allowed Timestep: 0.33333334
   m_TimeScale: 1
   Maximum Particle Timestep: 0.03


### PR DESCRIPTION
test in procedural test scene.
During my testing it seemed that 1/5 of the times I shot the head it would not detect it. I tried increasing the collision detection mode and also increasing the radius of the heads collider. This fixed all of nothing so I tried googling it and at the cost of some performance you can change the fixed timestep in project settings to a lower number and that seemed to do the trick