### PR TITLE
updated chase sequence prefabs

### DIFF
--- a/Assets/GameAssets/World/WorldPrefabs/Mazes/Ending Chase Sequence.prefab
+++ b/Assets/GameAssets/World/WorldPrefabs/Mazes/Ending Chase Sequence.prefab
@@ -1,124 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &155258701358878744
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 772438186797008709}
-  - component: {fileID: 600455682587977281}
-  - component: {fileID: 6410346242556918277}
-  - component: {fileID: 1428736445251567471}
-  - component: {fileID: 4629177129285346114}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (6)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &772438186797008709
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 155258701358878744}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.497635, y: -0.82162476, z: -1.0480957}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8410048339011494534}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &600455682587977281
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 155258701358878744}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &6410346242556918277
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 155258701358878744}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &1428736445251567471
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 155258701358878744}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &4629177129285346114
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 155258701358878744}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
 --- !u!1 &181988420091726092
 GameObject:
   m_ObjectHideFlags: 0
@@ -268,7 +149,7 @@ Transform:
   m_GameObject: {fileID: 218648315243193983}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 127.82043, y: -5.7048264, z: 9.69986}
+  m_LocalPosition: {x: 127.82043, y: -5.7048264, z: 6.7299805}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2334,244 +2215,6 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
---- !u!1 &401044198262876119
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2460145219091655892}
-  - component: {fileID: 6060404633011055276}
-  - component: {fileID: 211308540493678778}
-  - component: {fileID: 9022692752112589376}
-  - component: {fileID: 4391543664015030}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (3)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2460145219091655892
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 401044198262876119}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.429451, y: -1.9886248, z: -1.0542908}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8410048339011494534}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &6060404633011055276
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 401044198262876119}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &211308540493678778
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 401044198262876119}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &9022692752112589376
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 401044198262876119}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &4391543664015030
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 401044198262876119}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
---- !u!1 &426884393747655105
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3348563850490208567}
-  - component: {fileID: 4750040261861905198}
-  - component: {fileID: 6946889586070535462}
-  - component: {fileID: 3039247735846103486}
-  - component: {fileID: 3293271988708271345}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (5)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3348563850490208567
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 426884393747655105}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.4461823, y: -1.2756248, z: 0.036987305}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5618225657682963032}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &4750040261861905198
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 426884393747655105}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &6946889586070535462
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 426884393747655105}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &3039247735846103486
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 426884393747655105}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &3293271988708271345
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 426884393747655105}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
 --- !u!1 &430371268380461262
 GameObject:
   m_ObjectHideFlags: 0
@@ -2691,125 +2334,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _maxHealth: 0
---- !u!1 &580642664721339321
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2423995836372801272}
-  - component: {fileID: 3651761406929018705}
-  - component: {fileID: 7492457280276870434}
-  - component: {fileID: 4795858253251626556}
-  - component: {fileID: 5298700875462926441}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2423995836372801272
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 580642664721339321}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.48378, y: -2.4486248, z: -0.12988281}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8410048339011494534}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &3651761406929018705
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 580642664721339321}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &7492457280276870434
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 580642664721339321}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &4795858253251626556
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 580642664721339321}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &5298700875462926441
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 580642664721339321}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
 --- !u!1 &722378335045323277
 GameObject:
   m_ObjectHideFlags: 0
@@ -2840,7 +2364,7 @@ Transform:
   m_GameObject: {fileID: 722378335045323277}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 127.82043, y: -5.7048264, z: 19.68985}
+  m_LocalPosition: {x: 127.82043, y: -5.7048264, z: 16.71997}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3580,125 +3104,6 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
---- !u!1 &787802658559433738
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2718321388147882668}
-  - component: {fileID: 668501277636151344}
-  - component: {fileID: 3415246532651681850}
-  - component: {fileID: 5844616270822459859}
-  - component: {fileID: 4220834708254057213}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (7)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2718321388147882668
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 787802658559433738}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.4789047, y: -0.7236247, z: 0.15765381}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5618225657682963032}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &668501277636151344
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 787802658559433738}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &3415246532651681850
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 787802658559433738}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &5844616270822459859
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 787802658559433738}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &4220834708254057213
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 787802658559433738}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
 --- !u!1 &961584414172273852
 GameObject:
   m_ObjectHideFlags: 0
@@ -3848,7 +3253,7 @@ Transform:
   m_GameObject: {fileID: 1092041234212482675}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 130.90042, y: -5.7048264, z: -10.31015}
+  m_LocalPosition: {x: 130.90042, y: -5.7048264, z: -13.280029}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -7013,125 +6418,6 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
---- !u!1 &1519039505295038315
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8199618758389594329}
-  - component: {fileID: 821878793010652768}
-  - component: {fileID: 5156942521139183101}
-  - component: {fileID: 5727241995616198505}
-  - component: {fileID: 9054351745860610796}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (7)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8199618758389594329
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519039505295038315}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.4789047, y: -0.7236247, z: 0.15765381}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8410048339011494534}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &821878793010652768
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519039505295038315}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &5156942521139183101
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519039505295038315}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &5727241995616198505
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519039505295038315}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &9054351745860610796
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519039505295038315}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
 --- !u!1 &1551558902519769740
 GameObject:
   m_ObjectHideFlags: 0
@@ -10272,125 +9558,6 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
---- !u!1 &1717347463663663057
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5834478663742057848}
-  - component: {fileID: 1722829491764411608}
-  - component: {fileID: 7502253538725650574}
-  - component: {fileID: 1463708295575962974}
-  - component: {fileID: 1646153135501439307}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (5)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5834478663742057848
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1717347463663663057}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.4461823, y: -1.2756248, z: 0.036987305}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8410048339011494534}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &1722829491764411608
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1717347463663663057}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &7502253538725650574
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1717347463663663057}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &1463708295575962974
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1717347463663663057}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &1646153135501439307
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1717347463663663057}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
 --- !u!1 &1746909922322072103
 GameObject:
   m_ObjectHideFlags: 0
@@ -10629,164 +9796,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _maxHealth: 0
---- !u!1 &2066007798384965184
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5618225657682963032}
-  m_Layer: 0
-  m_Name: Crate Pile  (3)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5618225657682963032
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2066007798384965184}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 131.029, y: -2.6753752, z: -21.853}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4605071679686218372}
-  - {fileID: 1463767763375590934}
-  - {fileID: 2007846179435829671}
-  - {fileID: 8903455986912562286}
-  - {fileID: 6643897596989150801}
-  - {fileID: 3348563850490208567}
-  - {fileID: 4355574270947390507}
-  - {fileID: 2718321388147882668}
-  m_Father: {fileID: 7716199184528678064}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2145380362545577869
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4355574270947390507}
-  - component: {fileID: 5634481221596160077}
-  - component: {fileID: 6222386395811576505}
-  - component: {fileID: 6518666205583014955}
-  - component: {fileID: 7861881486806805286}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (6)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4355574270947390507
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2145380362545577869}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.497635, y: -0.82162476, z: -1.0480957}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5618225657682963032}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &5634481221596160077
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2145380362545577869}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &6222386395811576505
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2145380362545577869}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &6518666205583014955
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2145380362545577869}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &7861881486806805286
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2145380362545577869}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
 --- !u!1 &2388013633409211980
 GameObject:
   m_ObjectHideFlags: 0
@@ -10936,7 +9945,7 @@ Transform:
   m_GameObject: {fileID: 2519479764471326562}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 127.80443, y: -5.7048264, z: 29.688843}
+  m_LocalPosition: {x: 127.80443, y: -5.7048264, z: 26.718964}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -13958,7 +12967,7 @@ Transform:
   m_GameObject: {fileID: 2987397674193407182}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
-  m_LocalPosition: {x: 110.80043, y: -5.7048264, z: -13.720154}
+  m_LocalPosition: {x: 110.97, y: -5.68, z: -16.7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -15403,7 +14412,7 @@ Transform:
   m_GameObject: {fileID: 3312484307550798247}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 120.87043, y: -5.7048264, z: -23.860138}
+  m_LocalPosition: {x: 120.93, y: -5.7048264, z: -26.72}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -17096,125 +16105,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _maxHealth: 0
---- !u!1 &3869593728812575122
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8273136066350937025}
-  - component: {fileID: 8375642987938617991}
-  - component: {fileID: 1665118086199936714}
-  - component: {fileID: 5997580411747455449}
-  - component: {fileID: 7520438135295843764}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (4)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8273136066350937025
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3869593728812575122}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.451065, y: -1.3646247, z: -1.0705566}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8410048339011494534}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &8375642987938617991
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3869593728812575122}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &1665118086199936714
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3869593728812575122}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &5997580411747455449
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3869593728812575122}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &7520438135295843764
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3869593728812575122}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
 --- !u!1 &4168879671373932791
 GameObject:
   m_ObjectHideFlags: 0
@@ -17245,7 +16135,7 @@ Transform:
   m_GameObject: {fileID: 4168879671373932791}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 127.81043, y: -5.7048264, z: 29.68985}
+  m_LocalPosition: {x: 127.81043, y: -5.7048264, z: 26.71997}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -18009,8 +16899,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4258847446962907389}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 134.24, y: -2.6753752, z: -58.77}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 130.29, y: -2.6753752, z: -55.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -18023,1900 +16913,7 @@ Transform:
   - {fileID: 3832456103489257402}
   - {fileID: 2143657468511702948}
   m_Father: {fileID: 7716199184528678064}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4669266147446026746
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5135478871214102639}
-  - component: {fileID: 3050013896236416747}
-  - component: {fileID: 9051960268409738459}
-  - component: {fileID: 3170477319006549408}
-  - component: {fileID: 6549609900711215563}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5135478871214102639
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4669266147446026746}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.5552063, y: -2.5216248, z: -1.2497559}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8410048339011494534}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &3050013896236416747
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4669266147446026746}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &9051960268409738459
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4669266147446026746}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &3170477319006549408
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4669266147446026746}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &6549609900711215563
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4669266147446026746}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
---- !u!1 &4829947429987227257
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5725746646303265768}
-  - component: {fileID: 13956997133020929}
-  - component: {fileID: 3923304814177178804}
-  - component: {fileID: 6365818214527759148}
-  - component: {fileID: 1597600647752284838}
-  - component: {fileID: 1130996347670976406}
-  m_Layer: 0
-  m_Name: T-Int (3)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5725746646303265768
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4829947429987227257}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 120.80043, y: -5.7048264, z: -6.7291565}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7716199184528678064}
-  m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
---- !u!114 &13956997133020929
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4829947429987227257}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8233d90336aea43098adf6dbabd606a2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MeshFormatVersion: 2
-  m_Faces:
-  - m_Indexes: 010000000200000000000000020000000700000000000000030000000400000002000000040000000700000002000000050000000700000004000000050000000600000007000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 0.25, y: 0.25}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
-    m_SubmeshIndex: 2
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 08000000090000000a0000000b000000080000000a0000000c000000080000000b0000000c0000000b0000000d0000000e000000080000000c0000000e0000000c0000000f000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
-    m_SubmeshIndex: 1
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 1c0000001d0000001b0000001c0000001b0000001a000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 0.25, y: 0.25}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 220000002300000024000000230000002500000024000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 260000002700000028000000270000002900000028000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 2a0000002b0000002c0000002b0000002d0000002c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 2e0000002f000000300000002f0000003100000030000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 320000003300000034000000330000003500000034000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 360000003700000038000000370000003900000038000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 3a0000003b0000003c0000003b0000003d0000003c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 3e0000003f000000400000003f0000004100000040000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 420000004300000044000000430000004500000044000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 4a0000004b0000004c0000004b0000004d0000004c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 4e0000004f000000500000004f0000005100000050000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 520000005300000054000000530000005500000054000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 560000005700000058000000570000005900000058000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 5a0000005b0000005c0000005b0000005d0000005c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 620000006300000064000000630000006500000064000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 660000006700000068000000670000006900000068000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 6a0000006b0000006c0000006b0000006d0000006c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 6e0000006f000000700000006f0000007100000070000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 720000007300000074000000730000007500000074000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 760000007700000078000000770000007900000078000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 7a0000007b0000007c0000007b0000007d0000007c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 7e0000007f000000800000007f0000008100000080000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 820000008300000084000000830000008500000084000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 860000008700000088000000870000008900000088000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 8a0000008b0000008c0000008b0000008d0000008c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 8e0000008f000000900000008f0000009100000090000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 920000009300000094000000930000009500000094000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 960000009700000098000000970000009900000098000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 9a0000009b0000009c0000009b0000009d0000009c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: a2000000a3000000a4000000a3000000a5000000a4000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: a6000000a7000000a8000000a7000000a9000000a8000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: aa000000ab000000ac000000ab000000ad000000ac000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: b0000000b1000000b2000000b1000000b3000000b2000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: b4000000b5000000b6000000b5000000b7000000b6000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: b8000000b9000000ba000000b9000000bb000000ba000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: bc000000bd000000be000000bd000000bf000000be000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: c0000000c1000000c2000000c1000000c3000000c2000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: c4000000c5000000c6000000c5000000c7000000c6000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: c8000000c9000000ca000000c9000000cb000000ca000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: cc000000cd000000ce000000cd000000cf000000ce000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 460000004700000048000000470000004900000048000000180000001900000017000000180000001700000016000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 0.25, y: 0.25}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 5e0000005f000000600000005f000000610000006000000020000000210000001f000000200000001f0000001e000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 0.25, y: 0.25}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: 1
-    m_TextureGroup: -1
-  - m_Indexes: 1400000015000000130000001400000013000000120000001400000012000000ae00000012000000af000000ae000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 0.25, y: 0.25}
-      m_Offset: {x: -7.5, y: -0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: 1
-    m_TextureGroup: -1
-  - m_Indexes: 9e0000009f000000a00000009f000000a1000000a0000000110000009f0000009e000000110000009e00000010000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 0.25, y: 0.25}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  m_SharedVertices:
-  - m_Vertices: 00000000280000002d000000
-  - m_Vertices: 260000002b000000570000005a000000
-  - m_Vertices: 13000000590000005c000000
-  - m_Vertices: 0e000000c6000000cf000000
-  - m_Vertices: 5300000056000000c4000000cd000000
-  - m_Vertices: 150000005500000058000000
-  - m_Vertices: 010000002400000029000000
-  - m_Vertices: 100000004d00000050000000
-  - m_Vertices: 22000000270000004b0000004e000000
-  - m_Vertices: 0f000000cb000000ce000000
-  - m_Vertices: 420000004f000000c9000000cc000000
-  - m_Vertices: 110000004400000051000000
-  - m_Vertices: 020000002500000034000000
-  - m_Vertices: 4c0000009b0000009e000000
-  - m_Vertices: 490000009d000000a0000000
-  - m_Vertices: 160000007d00000080000000
-  - m_Vertices: 23000000320000004a0000007b0000007e000000930000009a000000
-  - m_Vertices: 47000000950000009c000000
-  - m_Vertices: 0c000000c3000000ca000000
-  - m_Vertices: 43000000720000007f0000009200000097000000c1000000c8000000
-  - m_Vertices: 460000009400000099000000
-  - m_Vertices: 180000007400000081000000
-  - m_Vertices: 45000000960000009f000000
-  - m_Vertices: 4800000098000000a1000000
-  - m_Vertices: 030000003000000035000000
-  - m_Vertices: 2e00000033000000770000007a000000
-  - m_Vertices: 17000000790000007c000000
-  - m_Vertices: 0d000000bf000000c2000000
-  - m_Vertices: 7300000076000000bd000000c0000000
-  - m_Vertices: 190000007500000078000000
-  - m_Vertices: 040000003100000038000000
-  - m_Vertices: 2f000000360000008b0000008e000000
-  - m_Vertices: 1a0000008d00000090000000
-  - m_Vertices: 0b000000bb000000be000000
-  - m_Vertices: 820000008f000000b9000000bc000000
-  - m_Vertices: 1c0000008400000091000000
-  - m_Vertices: 05000000390000003c000000
-  - m_Vertices: 1b000000890000008c000000
-  - m_Vertices: 370000003a000000870000008a000000
-  - m_Vertices: 0a000000b7000000ba000000
-  - m_Vertices: 8300000086000000b5000000b8000000
-  - m_Vertices: 1d0000008500000088000000
-  - m_Vertices: 060000003d00000040000000
-  - m_Vertices: 3b0000003e0000006b0000006e000000
-  - m_Vertices: 1e0000006d00000070000000
-  - m_Vertices: 09000000b3000000b6000000
-  - m_Vertices: 620000006f000000b1000000b4000000
-  - m_Vertices: 200000006400000071000000
-  - m_Vertices: 070000002c00000041000000
-  - m_Vertices: 120000005d000000a6000000
-  - m_Vertices: 60000000a8000000af000000
-  - m_Vertices: 1f000000690000006c000000
-  - m_Vertices: 2a0000003f0000005b000000670000006a000000a2000000a7000000
-  - m_Vertices: 5e000000a4000000a9000000
-  - m_Vertices: 08000000b2000000c7000000
-  - m_Vertices: 520000006300000066000000a3000000aa000000b0000000c5000000
-  - m_Vertices: 5f000000a5000000ac000000
-  - m_Vertices: 210000006500000068000000
-  - m_Vertices: 1400000054000000ab000000
-  - m_Vertices: 61000000ad000000ae000000
-  m_SharedTextures:
-  - m_Vertices: 61000000ae000000
-  - m_Vertices: 60000000af000000
-  m_Positions:
-  - {x: 0, y: 0.25, z: 0}
-  - {x: 3, y: 0.25, z: 0}
-  - {x: 3, y: 0.25, z: -7}
-  - {x: 6.5, y: 0.25, z: -7}
-  - {x: 6.5, y: 0.25, z: -10}
-  - {x: -3.5, y: 0.25, z: -10}
-  - {x: -3.5, y: 0.25, z: -7}
-  - {x: 0, y: 0.25, z: -7}
-  - {x: 0, y: 2.75, z: -7}
-  - {x: -3.5, y: 2.75, z: -7}
-  - {x: -3.5, y: 2.75, z: -10}
-  - {x: 6.5, y: 2.75, z: -10}
-  - {x: 3, y: 2.75, z: -7}
-  - {x: 6.5, y: 2.75, z: -7}
-  - {x: 0, y: 2.75, z: 0}
-  - {x: 3, y: 2.75, z: 0}
-  - {x: 2.75, y: 0, z: 0}
-  - {x: 2.75, y: 3, z: 0}
-  - {x: 0.25, y: 0, z: -7}
-  - {x: 0.25, y: 0, z: 0}
-  - {x: 0.25, y: 3, z: -7}
-  - {x: 0.25, y: 3, z: 0}
-  - {x: 3, y: 0, z: -7.25}
-  - {x: 6.5, y: 0, z: -7.25}
-  - {x: 3, y: 3, z: -7.25}
-  - {x: 6.5, y: 3, z: -7.25}
-  - {x: 6.5, y: 0, z: -9.75}
-  - {x: -3.5, y: 0, z: -9.75}
-  - {x: 6.5, y: 3, z: -9.75}
-  - {x: -3.5, y: 3, z: -9.75}
-  - {x: -3.5, y: 0, z: -7.25}
-  - {x: 0, y: 0, z: -7.25}
-  - {x: -3.5, y: 3, z: -7.25}
-  - {x: 0, y: 3, z: -7.25}
-  - {x: 3, y: 0, z: 0}
-  - {x: 3, y: 0, z: -7}
-  - {x: 3, y: 0.25, z: 0}
-  - {x: 3, y: 0.25, z: -7}
-  - {x: 0, y: 0, z: 0}
-  - {x: 3, y: 0, z: 0}
-  - {x: 0, y: 0.25, z: 0}
-  - {x: 3, y: 0.25, z: 0}
-  - {x: 0, y: 0, z: -7}
-  - {x: 0, y: 0, z: 0}
-  - {x: 0, y: 0.25, z: -7}
-  - {x: 0, y: 0.25, z: 0}
-  - {x: 6.5, y: 0, z: -7}
-  - {x: 6.5, y: 0, z: -10}
-  - {x: 6.5, y: 0.25, z: -7}
-  - {x: 6.5, y: 0.25, z: -10}
-  - {x: 3, y: 0, z: -7}
-  - {x: 6.5, y: 0, z: -7}
-  - {x: 3, y: 0.25, z: -7}
-  - {x: 6.5, y: 0.25, z: -7}
-  - {x: 6.5, y: 0, z: -10}
-  - {x: -3.5, y: 0, z: -10}
-  - {x: 6.5, y: 0.25, z: -10}
-  - {x: -3.5, y: 0.25, z: -10}
-  - {x: -3.5, y: 0, z: -10}
-  - {x: -3.5, y: 0, z: -7}
-  - {x: -3.5, y: 0.25, z: -10}
-  - {x: -3.5, y: 0.25, z: -7}
-  - {x: -3.5, y: 0, z: -7}
-  - {x: 0, y: 0, z: -7}
-  - {x: -3.5, y: 0.25, z: -7}
-  - {x: 0, y: 0.25, z: -7}
-  - {x: 3, y: 3, z: 0}
-  - {x: 3, y: 3, z: -7}
-  - {x: 2.75, y: 3, z: 0}
-  - {x: 2.75, y: 3, z: -7}
-  - {x: 3, y: 3, z: -7.25}
-  - {x: 3, y: 0, z: -7.25}
-  - {x: 2.75, y: 3, z: -7.25}
-  - {x: 2.75, y: 0, z: -7.25}
-  - {x: 3, y: 0, z: -7}
-  - {x: 3, y: 0, z: 0}
-  - {x: 2.75, y: 0, z: -7}
-  - {x: 2.75, y: 0, z: 0}
-  - {x: 3, y: 0, z: 0}
-  - {x: 3, y: 3, z: 0}
-  - {x: 2.75, y: 0, z: 0}
-  - {x: 2.75, y: 3, z: 0}
-  - {x: 0, y: 3, z: -7}
-  - {x: 0, y: 3, z: 0}
-  - {x: 0.25, y: 3, z: -7}
-  - {x: 0.25, y: 3, z: 0}
-  - {x: 0, y: 3, z: 0}
-  - {x: 0, y: 0, z: 0}
-  - {x: 0.25, y: 3, z: 0}
-  - {x: 0.25, y: 0, z: 0}
-  - {x: 0, y: 0, z: 0}
-  - {x: 0, y: 0, z: -7}
-  - {x: 0.25, y: 0, z: 0}
-  - {x: 0.25, y: 0, z: -7}
-  - {x: 0, y: 0, z: -7.25}
-  - {x: 0, y: 3, z: -7.25}
-  - {x: 0.25, y: 0, z: -7.25}
-  - {x: 0.25, y: 3, z: -7.25}
-  - {x: -3.5, y: 3, z: -7}
-  - {x: 0, y: 3, z: -7}
-  - {x: -3.5, y: 3, z: -7.25}
-  - {x: 0, y: 3, z: -7.25}
-  - {x: 0, y: 3, z: -7}
-  - {x: 0, y: 0, z: -7}
-  - {x: 0, y: 3, z: -7.25}
-  - {x: 0, y: 0, z: -7.25}
-  - {x: 0, y: 0, z: -7}
-  - {x: -3.5, y: 0, z: -7}
-  - {x: 0, y: 0, z: -7.25}
-  - {x: -3.5, y: 0, z: -7.25}
-  - {x: -3.5, y: 0, z: -7}
-  - {x: -3.5, y: 3, z: -7}
-  - {x: -3.5, y: 0, z: -7.25}
-  - {x: -3.5, y: 3, z: -7.25}
-  - {x: 3, y: 3, z: -7}
-  - {x: 6.5, y: 3, z: -7}
-  - {x: 3, y: 3, z: -7.25}
-  - {x: 6.5, y: 3, z: -7.25}
-  - {x: 6.5, y: 3, z: -7}
-  - {x: 6.5, y: 0, z: -7}
-  - {x: 6.5, y: 3, z: -7.25}
-  - {x: 6.5, y: 0, z: -7.25}
-  - {x: 6.5, y: 0, z: -7}
-  - {x: 3, y: 0, z: -7}
-  - {x: 6.5, y: 0, z: -7.25}
-  - {x: 3, y: 0, z: -7.25}
-  - {x: 3, y: 0, z: -7}
-  - {x: 3, y: 3, z: -7}
-  - {x: 3, y: 0, z: -7.25}
-  - {x: 3, y: 3, z: -7.25}
-  - {x: 6.5, y: 3, z: -10}
-  - {x: -3.5, y: 3, z: -10}
-  - {x: 6.5, y: 3, z: -9.75}
-  - {x: -3.5, y: 3, z: -9.75}
-  - {x: -3.5, y: 3, z: -10}
-  - {x: -3.5, y: 0, z: -10}
-  - {x: -3.5, y: 3, z: -9.75}
-  - {x: -3.5, y: 0, z: -9.75}
-  - {x: -3.5, y: 0, z: -10}
-  - {x: 6.5, y: 0, z: -10}
-  - {x: -3.5, y: 0, z: -9.75}
-  - {x: 6.5, y: 0, z: -9.75}
-  - {x: 6.5, y: 0, z: -10}
-  - {x: 6.5, y: 3, z: -10}
-  - {x: 6.5, y: 0, z: -9.75}
-  - {x: 6.5, y: 3, z: -9.75}
-  - {x: 3, y: 3, z: -7}
-  - {x: 3, y: 0, z: -7}
-  - {x: 3, y: 3, z: -7.25}
-  - {x: 3, y: 0, z: -7.25}
-  - {x: 2.75, y: 3, z: -7}
-  - {x: 3, y: 3, z: -7}
-  - {x: 2.75, y: 3, z: -7.25}
-  - {x: 3, y: 3, z: -7.25}
-  - {x: 3, y: 0, z: -7}
-  - {x: 2.75, y: 0, z: -7}
-  - {x: 3, y: 0, z: -7.25}
-  - {x: 2.75, y: 0, z: -7.25}
-  - {x: 2.75, y: 0, z: -7}
-  - {x: 2.75, y: 3, z: -7}
-  - {x: 2.75, y: 0, z: -7.25}
-  - {x: 2.75, y: 3, z: -7.25}
-  - {x: 0, y: 0, z: -7}
-  - {x: 0, y: 3, z: -7}
-  - {x: 0, y: 0, z: -7.25}
-  - {x: 0, y: 3, z: -7.25}
-  - {x: 0.25, y: 0, z: -7}
-  - {x: 0, y: 0, z: -7}
-  - {x: 0.25, y: 0, z: -7.25}
-  - {x: 0, y: 0, z: -7.25}
-  - {x: 0, y: 3, z: -7}
-  - {x: 0.25, y: 3, z: -7}
-  - {x: 0, y: 3, z: -7.25}
-  - {x: 0.25, y: 3, z: -7.25}
-  - {x: 0.25, y: 3, z: -7.25}
-  - {x: 0.25, y: 0, z: -7.25}
-  - {x: 0, y: 3, z: -7}
-  - {x: -3.5, y: 3, z: -7}
-  - {x: 0, y: 2.75, z: -7}
-  - {x: -3.5, y: 2.75, z: -7}
-  - {x: -3.5, y: 3, z: -7}
-  - {x: -3.5, y: 3, z: -10}
-  - {x: -3.5, y: 2.75, z: -7}
-  - {x: -3.5, y: 2.75, z: -10}
-  - {x: -3.5, y: 3, z: -10}
-  - {x: 6.5, y: 3, z: -10}
-  - {x: -3.5, y: 2.75, z: -10}
-  - {x: 6.5, y: 2.75, z: -10}
-  - {x: 6.5, y: 3, z: -10}
-  - {x: 6.5, y: 3, z: -7}
-  - {x: 6.5, y: 2.75, z: -10}
-  - {x: 6.5, y: 2.75, z: -7}
-  - {x: 6.5, y: 3, z: -7}
-  - {x: 3, y: 3, z: -7}
-  - {x: 6.5, y: 2.75, z: -7}
-  - {x: 3, y: 2.75, z: -7}
-  - {x: 0, y: 3, z: 0}
-  - {x: 0, y: 3, z: -7}
-  - {x: 0, y: 2.75, z: 0}
-  - {x: 0, y: 2.75, z: -7}
-  - {x: 3, y: 3, z: -7}
-  - {x: 3, y: 3, z: 0}
-  - {x: 3, y: 2.75, z: -7}
-  - {x: 3, y: 2.75, z: 0}
-  - {x: 3, y: 3, z: 0}
-  - {x: 0, y: 3, z: 0}
-  - {x: 3, y: 2.75, z: 0}
-  - {x: 0, y: 2.75, z: 0}
-  m_Textures0:
-  - {x: 0, y: 0}
-  - {x: 0.75, y: 0}
-  - {x: 0.75, y: -1.75}
-  - {x: 1.625, y: -1.75}
-  - {x: 1.625, y: -2.5}
-  - {x: -0.875, y: -2.5}
-  - {x: -0.875, y: -1.75}
-  - {x: 0, y: -1.75}
-  - {x: 0, y: -7}
-  - {x: 3.5, y: -7}
-  - {x: 3.5, y: -10}
-  - {x: -6.5, y: -10}
-  - {x: -3, y: -7}
-  - {x: -6.5, y: -7}
-  - {x: 0, y: 0}
-  - {x: -3, y: 0}
-  - {x: 0, y: 0}
-  - {x: 0, y: 0.75}
-  - {x: 5.75, y: 0}
-  - {x: 7.5, y: 0}
-  - {x: 5.75, y: 0.75}
-  - {x: 7.5, y: 0.75}
-  - {x: 0.75, y: 0}
-  - {x: 1.625, y: 0}
-  - {x: 0.75, y: 0.75}
-  - {x: 1.625, y: 0.75}
-  - {x: -1.625, y: 0}
-  - {x: 0.875, y: 0}
-  - {x: -1.625, y: 0.75}
-  - {x: 0.875, y: 0.75}
-  - {x: -0.875, y: 0}
-  - {x: 0, y: 0}
-  - {x: -0.875, y: 0.75}
-  - {x: 0, y: 0.75}
-  - {x: 0, y: 0}
-  - {x: -7, y: 0}
-  - {x: 0, y: 0.25}
-  - {x: -7, y: 0.25}
-  - {x: 0, y: 0}
-  - {x: -3, y: 0}
-  - {x: 0, y: 0.25}
-  - {x: -3, y: 0.25}
-  - {x: 7, y: 0}
-  - {x: 0, y: 0}
-  - {x: 7, y: 0.25}
-  - {x: 0, y: 0.25}
-  - {x: -7, y: 0}
-  - {x: -10, y: 0}
-  - {x: -7, y: 0.25}
-  - {x: -10, y: 0.25}
-  - {x: -3, y: 0}
-  - {x: -6.5, y: 0}
-  - {x: -3, y: 0.25}
-  - {x: -6.5, y: 0.25}
-  - {x: 6.5, y: 0}
-  - {x: -3.5, y: 0}
-  - {x: 6.5, y: 0.25}
-  - {x: -3.5, y: 0.25}
-  - {x: 10, y: 0}
-  - {x: 7, y: 0}
-  - {x: 10, y: 0.25}
-  - {x: 7, y: 0.25}
-  - {x: 3.5, y: 0}
-  - {x: 0, y: 0}
-  - {x: 3.5, y: 0.25}
-  - {x: 0, y: 0.25}
-  - {x: 3, y: 0}
-  - {x: 3, y: -7}
-  - {x: 2.75, y: 0}
-  - {x: 2.75, y: -7}
-  - {x: 0.75, y: 0.75}
-  - {x: 0.75, y: 0}
-  - {x: 0.6875, y: 0.75}
-  - {x: 0.6875, y: 0}
-  - {x: -3, y: -7}
-  - {x: -3, y: 0}
-  - {x: -2.75, y: -7}
-  - {x: -2.75, y: 0}
-  - {x: -3, y: 0}
-  - {x: -3, y: 3}
-  - {x: -2.75, y: 0}
-  - {x: -2.75, y: 3}
-  - {x: 0, y: -7}
-  - {x: 0, y: 0}
-  - {x: 0.25, y: -7}
-  - {x: 0.25, y: 0}
-  - {x: 0, y: 3}
-  - {x: 0, y: 0}
-  - {x: -0.25, y: 3}
-  - {x: -0.25, y: 0}
-  - {x: 0, y: 0}
-  - {x: 0, y: -7}
-  - {x: -0.25, y: 0}
-  - {x: -0.25, y: -7}
-  - {x: 0, y: 0}
-  - {x: 0, y: 0.75}
-  - {x: 0.0625, y: 0}
-  - {x: 0.0625, y: 0.75}
-  - {x: -3.5, y: -7}
-  - {x: 0, y: -7}
-  - {x: -3.5, y: -7.25}
-  - {x: 0, y: -7.25}
-  - {x: -7, y: 3}
-  - {x: -7, y: 0}
-  - {x: -7.25, y: 3}
-  - {x: -7.25, y: 0}
-  - {x: 0, y: -7}
-  - {x: 3.5, y: -7}
-  - {x: 0, y: -7.25}
-  - {x: 3.5, y: -7.25}
-  - {x: 7, y: 0}
-  - {x: 7, y: 3}
-  - {x: 7.25, y: 0}
-  - {x: 7.25, y: 3}
-  - {x: 3, y: -7}
-  - {x: 6.5, y: -7}
-  - {x: 3, y: -7.25}
-  - {x: 6.5, y: -7.25}
-  - {x: -7, y: 3}
-  - {x: -7, y: 0}
-  - {x: -7.25, y: 3}
-  - {x: -7.25, y: 0}
-  - {x: -6.5, y: -7}
-  - {x: -3, y: -7}
-  - {x: -6.5, y: -7.25}
-  - {x: -3, y: -7.25}
-  - {x: 7, y: 0}
-  - {x: 7, y: 3}
-  - {x: 7.25, y: 0}
-  - {x: 7.25, y: 3}
-  - {x: 6.5, y: -10}
-  - {x: -3.5, y: -10}
-  - {x: 6.5, y: -9.75}
-  - {x: -3.5, y: -9.75}
-  - {x: 10, y: 3}
-  - {x: 10, y: 0}
-  - {x: 9.75, y: 3}
-  - {x: 9.75, y: 0}
-  - {x: 3.5, y: -10}
-  - {x: -6.5, y: -10}
-  - {x: 3.5, y: -9.75}
-  - {x: -6.5, y: -9.75}
-  - {x: -10, y: 0}
-  - {x: -10, y: 3}
-  - {x: -9.75, y: 0}
-  - {x: -9.75, y: 3}
-  - {x: -7, y: 3}
-  - {x: -7, y: 0}
-  - {x: -7.25, y: 3}
-  - {x: -7.25, y: 0}
-  - {x: 2.75, y: -7}
-  - {x: 3, y: -7}
-  - {x: 2.75, y: -7.25}
-  - {x: 3, y: -7.25}
-  - {x: -3, y: -7}
-  - {x: -2.75, y: -7}
-  - {x: -3, y: -7.25}
-  - {x: -2.75, y: -7.25}
-  - {x: 1.75, y: 0}
-  - {x: 1.75, y: 0.75}
-  - {x: 1.8125, y: 0}
-  - {x: 1.8125, y: 0.75}
-  - {x: 7, y: 0}
-  - {x: 7, y: 3}
-  - {x: 7.25, y: 0}
-  - {x: 7.25, y: 3}
-  - {x: -0.25, y: -7}
-  - {x: 0, y: -7}
-  - {x: -0.25, y: -7.25}
-  - {x: 0, y: -7.25}
-  - {x: 0, y: -7}
-  - {x: 0.25, y: -7}
-  - {x: 0, y: -7.25}
-  - {x: 0.25, y: -7.25}
-  - {x: 5.6875, y: 0.75}
-  - {x: 5.6875, y: 0}
-  - {x: 0, y: 3}
-  - {x: 3.5, y: 3}
-  - {x: 0, y: 2.75}
-  - {x: 3.5, y: 2.75}
-  - {x: 7, y: 3}
-  - {x: 10, y: 3}
-  - {x: 7, y: 2.75}
-  - {x: 10, y: 2.75}
-  - {x: -3.5, y: 3}
-  - {x: 6.5, y: 3}
-  - {x: -3.5, y: 2.75}
-  - {x: 6.5, y: 2.75}
-  - {x: -10, y: 3}
-  - {x: -7, y: 3}
-  - {x: -10, y: 2.75}
-  - {x: -7, y: 2.75}
-  - {x: -6.5, y: 3}
-  - {x: -3, y: 3}
-  - {x: -6.5, y: 2.75}
-  - {x: -3, y: 2.75}
-  - {x: 0, y: 3}
-  - {x: 7, y: 3}
-  - {x: 0, y: 2.75}
-  - {x: 7, y: 2.75}
-  - {x: -7, y: 3}
-  - {x: 0, y: 3}
-  - {x: -7, y: 2.75}
-  - {x: 0, y: 2.75}
-  - {x: -3, y: 3}
-  - {x: 0, y: 3}
-  - {x: -3, y: 2.75}
-  - {x: 0, y: 2.75}
-  m_Textures2: []
-  m_Textures3: []
-  m_Tangents:
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  m_Colors: []
-  m_UnwrapParameters:
-    m_HardAngle: 88
-    m_PackMargin: 20
-    m_AngleError: 8
-    m_AreaError: 15
-  m_PreserveMeshAssetOnDestroy: 0
-  assetGuid: 
-  m_Mesh: {fileID: 0}
-  m_VersionIndex: 624
-  m_IsSelectable: 1
-  m_SelectedFaces: 
-  m_SelectedEdges: []
-  m_SelectedVertices: 
---- !u!114 &3923304814177178804
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4829947429987227257}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bb977b126bc1b4f15813dcf9da9bb600, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Points:
-  - {x: 0, y: 0, z: 0}
-  - {x: 3, y: 0, z: 0}
-  - {x: 3, y: 0, z: -7}
-  - {x: 6.5, y: 0, z: -7}
-  - {x: 6.5, y: 0, z: -10}
-  - {x: -3.5, y: 0, z: -10}
-  - {x: -3.5, y: 0, z: -7}
-  - {x: 0, y: 0, z: -7}
-  m_Extrude: 3
-  m_EditMode: 0
-  m_FlipNormals: 1
-  isOnGrid: 1
---- !u!23 &6365818214527759148
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4829947429987227257}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 5286def77a8bc454c85306f41471fe12, type: 2}
-  - {fileID: 2100000, guid: 86d8460c276ddfa4993fffe0c2069fbf, type: 2}
-  - {fileID: 2100000, guid: 4341072563c50c6408f10da8e6c5a74a, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 2
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1597600647752284838
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4829947429987227257}
-  m_Mesh: {fileID: 0}
---- !u!64 &1130996347670976406
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4829947429987227257}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 0
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 0}
---- !u!1 &4895575125901804195
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2007846179435829671}
-  - component: {fileID: 1715648890225894739}
-  - component: {fileID: 1509377120217115046}
-  - component: {fileID: 335917074985175223}
-  - component: {fileID: 5700609710017403784}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2007846179435829671
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4895575125901804195}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.3652878, y: -1.8236248, z: 0.12814331}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5618225657682963032}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &1715648890225894739
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4895575125901804195}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &1509377120217115046
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4895575125901804195}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &335917074985175223
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4895575125901804195}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &5700609710017403784
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4895575125901804195}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1 &4914634168700861279
 GameObject:
   m_ObjectHideFlags: 0
@@ -19941,8 +16938,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4914634168700861279}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 134.84, y: -2.6753752, z: -41.77}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 130, y: -2.6753752, z: -25.29}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -19955,7 +16952,7 @@ Transform:
   - {fileID: 9064888412945392197}
   - {fileID: 1747538591748973875}
   m_Father: {fileID: 7716199184528678064}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1 &5089789014721700875
 GameObject:
   m_ObjectHideFlags: 0
@@ -21083,1661 +18080,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _maxHealth: 0
---- !u!1 &5406731352137547262
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5150440261622003823}
-  - component: {fileID: 594035125376615558}
-  - component: {fileID: 4502925545583902515}
-  - component: {fileID: 5789403625473202347}
-  - component: {fileID: 2171908539241877793}
-  - component: {fileID: 557849540726782993}
-  m_Layer: 0
-  m_Name: T-Int (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5150440261622003823
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5406731352137547262}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 137.90042, y: -5.7048264, z: -40.730133}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7716199184528678064}
-  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
---- !u!114 &594035125376615558
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5406731352137547262}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8233d90336aea43098adf6dbabd606a2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MeshFormatVersion: 2
-  m_Faces:
-  - m_Indexes: 010000000200000000000000020000000700000000000000030000000400000002000000040000000700000002000000050000000700000004000000050000000600000007000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 0.25, y: 0.25}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
-    m_SubmeshIndex: 2
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 08000000090000000a0000000b000000080000000a0000000c000000080000000b0000000c0000000b0000000d0000000e000000080000000c0000000e0000000c0000000f000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
-    m_SubmeshIndex: 1
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 1c0000001d0000001b0000001c0000001b0000001a000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 0.25, y: 0.25}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 220000002300000024000000230000002500000024000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 260000002700000028000000270000002900000028000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 2a0000002b0000002c0000002b0000002d0000002c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 2e0000002f000000300000002f0000003100000030000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 320000003300000034000000330000003500000034000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 360000003700000038000000370000003900000038000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 3a0000003b0000003c0000003b0000003d0000003c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 3e0000003f000000400000003f0000004100000040000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 420000004300000044000000430000004500000044000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 4a0000004b0000004c0000004b0000004d0000004c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 4e0000004f000000500000004f0000005100000050000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 520000005300000054000000530000005500000054000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 560000005700000058000000570000005900000058000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 5a0000005b0000005c0000005b0000005d0000005c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 620000006300000064000000630000006500000064000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 660000006700000068000000670000006900000068000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 6a0000006b0000006c0000006b0000006d0000006c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 6e0000006f000000700000006f0000007100000070000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 720000007300000074000000730000007500000074000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 760000007700000078000000770000007900000078000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 7a0000007b0000007c0000007b0000007d0000007c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 7e0000007f000000800000007f0000008100000080000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 820000008300000084000000830000008500000084000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 860000008700000088000000870000008900000088000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 8a0000008b0000008c0000008b0000008d0000008c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 8e0000008f000000900000008f0000009100000090000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 920000009300000094000000930000009500000094000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 960000009700000098000000970000009900000098000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 9a0000009b0000009c0000009b0000009d0000009c000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: a2000000a3000000a4000000a3000000a5000000a4000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: a6000000a7000000a8000000a7000000a9000000a8000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: aa000000ab000000ac000000ab000000ad000000ac000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: b0000000b1000000b2000000b1000000b3000000b2000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: b4000000b5000000b6000000b5000000b7000000b6000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: b8000000b9000000ba000000b9000000bb000000ba000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: bc000000bd000000be000000bd000000bf000000be000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: c0000000c1000000c2000000c1000000c3000000c2000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: c4000000c5000000c6000000c5000000c7000000c6000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: c8000000c9000000ca000000c9000000cb000000ca000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: cc000000cd000000ce000000cd000000cf000000ce000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 1, y: 1}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 460000004700000048000000470000004900000048000000180000001900000017000000180000001700000016000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 0.25, y: 0.25}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  - m_Indexes: 5e0000005f000000600000005f000000610000006000000020000000210000001f000000200000001f0000001e000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 0.25, y: 0.25}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: 1
-    m_TextureGroup: -1
-  - m_Indexes: 1400000015000000130000001400000013000000120000001400000012000000ae00000012000000af000000ae000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 0.25, y: 0.25}
-      m_Offset: {x: -7.5, y: -0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: 1
-    m_TextureGroup: -1
-  - m_Indexes: 9e0000009f000000a00000009f000000a1000000a0000000110000009f0000009e000000110000009e00000010000000
-    m_SmoothingGroup: 0
-    m_Uv:
-      m_UseWorldSpace: 0
-      m_FlipU: 0
-      m_FlipV: 0
-      m_SwapUV: 0
-      m_Fill: 1
-      m_Scale: {x: 0.25, y: 0.25}
-      m_Offset: {x: 0, y: 0}
-      m_Rotation: 0
-      m_Anchor: 9
-    m_Material: {fileID: 0}
-    m_SubmeshIndex: 0
-    m_ManualUV: 0
-    elementGroup: -1
-    m_TextureGroup: -1
-  m_SharedVertices:
-  - m_Vertices: 00000000280000002d000000
-  - m_Vertices: 260000002b000000570000005a000000
-  - m_Vertices: 13000000590000005c000000
-  - m_Vertices: 0e000000c6000000cf000000
-  - m_Vertices: 5300000056000000c4000000cd000000
-  - m_Vertices: 150000005500000058000000
-  - m_Vertices: 010000002400000029000000
-  - m_Vertices: 100000004d00000050000000
-  - m_Vertices: 22000000270000004b0000004e000000
-  - m_Vertices: 0f000000cb000000ce000000
-  - m_Vertices: 420000004f000000c9000000cc000000
-  - m_Vertices: 110000004400000051000000
-  - m_Vertices: 020000002500000034000000
-  - m_Vertices: 4c0000009b0000009e000000
-  - m_Vertices: 490000009d000000a0000000
-  - m_Vertices: 160000007d00000080000000
-  - m_Vertices: 23000000320000004a0000007b0000007e000000930000009a000000
-  - m_Vertices: 47000000950000009c000000
-  - m_Vertices: 0c000000c3000000ca000000
-  - m_Vertices: 43000000720000007f0000009200000097000000c1000000c8000000
-  - m_Vertices: 460000009400000099000000
-  - m_Vertices: 180000007400000081000000
-  - m_Vertices: 45000000960000009f000000
-  - m_Vertices: 4800000098000000a1000000
-  - m_Vertices: 030000003000000035000000
-  - m_Vertices: 2e00000033000000770000007a000000
-  - m_Vertices: 17000000790000007c000000
-  - m_Vertices: 0d000000bf000000c2000000
-  - m_Vertices: 7300000076000000bd000000c0000000
-  - m_Vertices: 190000007500000078000000
-  - m_Vertices: 040000003100000038000000
-  - m_Vertices: 2f000000360000008b0000008e000000
-  - m_Vertices: 1a0000008d00000090000000
-  - m_Vertices: 0b000000bb000000be000000
-  - m_Vertices: 820000008f000000b9000000bc000000
-  - m_Vertices: 1c0000008400000091000000
-  - m_Vertices: 05000000390000003c000000
-  - m_Vertices: 1b000000890000008c000000
-  - m_Vertices: 370000003a000000870000008a000000
-  - m_Vertices: 0a000000b7000000ba000000
-  - m_Vertices: 8300000086000000b5000000b8000000
-  - m_Vertices: 1d0000008500000088000000
-  - m_Vertices: 060000003d00000040000000
-  - m_Vertices: 3b0000003e0000006b0000006e000000
-  - m_Vertices: 1e0000006d00000070000000
-  - m_Vertices: 09000000b3000000b6000000
-  - m_Vertices: 620000006f000000b1000000b4000000
-  - m_Vertices: 200000006400000071000000
-  - m_Vertices: 070000002c00000041000000
-  - m_Vertices: 120000005d000000a6000000
-  - m_Vertices: 60000000a8000000af000000
-  - m_Vertices: 1f000000690000006c000000
-  - m_Vertices: 2a0000003f0000005b000000670000006a000000a2000000a7000000
-  - m_Vertices: 5e000000a4000000a9000000
-  - m_Vertices: 08000000b2000000c7000000
-  - m_Vertices: 520000006300000066000000a3000000aa000000b0000000c5000000
-  - m_Vertices: 5f000000a5000000ac000000
-  - m_Vertices: 210000006500000068000000
-  - m_Vertices: 1400000054000000ab000000
-  - m_Vertices: 61000000ad000000ae000000
-  m_SharedTextures:
-  - m_Vertices: 61000000ae000000
-  - m_Vertices: 60000000af000000
-  m_Positions:
-  - {x: 0, y: 0.25, z: 0}
-  - {x: 3, y: 0.25, z: 0}
-  - {x: 3, y: 0.25, z: -7}
-  - {x: 6.5, y: 0.25, z: -7}
-  - {x: 6.5, y: 0.25, z: -10}
-  - {x: -3.5, y: 0.25, z: -10}
-  - {x: -3.5, y: 0.25, z: -7}
-  - {x: 0, y: 0.25, z: -7}
-  - {x: 0, y: 2.75, z: -7}
-  - {x: -3.5, y: 2.75, z: -7}
-  - {x: -3.5, y: 2.75, z: -10}
-  - {x: 6.5, y: 2.75, z: -10}
-  - {x: 3, y: 2.75, z: -7}
-  - {x: 6.5, y: 2.75, z: -7}
-  - {x: 0, y: 2.75, z: 0}
-  - {x: 3, y: 2.75, z: 0}
-  - {x: 2.75, y: 0, z: 0}
-  - {x: 2.75, y: 3, z: 0}
-  - {x: 0.25, y: 0, z: -7}
-  - {x: 0.25, y: 0, z: 0}
-  - {x: 0.25, y: 3, z: -7}
-  - {x: 0.25, y: 3, z: 0}
-  - {x: 3, y: 0, z: -7.25}
-  - {x: 6.5, y: 0, z: -7.25}
-  - {x: 3, y: 3, z: -7.25}
-  - {x: 6.5, y: 3, z: -7.25}
-  - {x: 6.5, y: 0, z: -9.75}
-  - {x: -3.5, y: 0, z: -9.75}
-  - {x: 6.5, y: 3, z: -9.75}
-  - {x: -3.5, y: 3, z: -9.75}
-  - {x: -3.5, y: 0, z: -7.25}
-  - {x: 0, y: 0, z: -7.25}
-  - {x: -3.5, y: 3, z: -7.25}
-  - {x: 0, y: 3, z: -7.25}
-  - {x: 3, y: 0, z: 0}
-  - {x: 3, y: 0, z: -7}
-  - {x: 3, y: 0.25, z: 0}
-  - {x: 3, y: 0.25, z: -7}
-  - {x: 0, y: 0, z: 0}
-  - {x: 3, y: 0, z: 0}
-  - {x: 0, y: 0.25, z: 0}
-  - {x: 3, y: 0.25, z: 0}
-  - {x: 0, y: 0, z: -7}
-  - {x: 0, y: 0, z: 0}
-  - {x: 0, y: 0.25, z: -7}
-  - {x: 0, y: 0.25, z: 0}
-  - {x: 6.5, y: 0, z: -7}
-  - {x: 6.5, y: 0, z: -10}
-  - {x: 6.5, y: 0.25, z: -7}
-  - {x: 6.5, y: 0.25, z: -10}
-  - {x: 3, y: 0, z: -7}
-  - {x: 6.5, y: 0, z: -7}
-  - {x: 3, y: 0.25, z: -7}
-  - {x: 6.5, y: 0.25, z: -7}
-  - {x: 6.5, y: 0, z: -10}
-  - {x: -3.5, y: 0, z: -10}
-  - {x: 6.5, y: 0.25, z: -10}
-  - {x: -3.5, y: 0.25, z: -10}
-  - {x: -3.5, y: 0, z: -10}
-  - {x: -3.5, y: 0, z: -7}
-  - {x: -3.5, y: 0.25, z: -10}
-  - {x: -3.5, y: 0.25, z: -7}
-  - {x: -3.5, y: 0, z: -7}
-  - {x: 0, y: 0, z: -7}
-  - {x: -3.5, y: 0.25, z: -7}
-  - {x: 0, y: 0.25, z: -7}
-  - {x: 3, y: 3, z: 0}
-  - {x: 3, y: 3, z: -7}
-  - {x: 2.75, y: 3, z: 0}
-  - {x: 2.75, y: 3, z: -7}
-  - {x: 3, y: 3, z: -7.25}
-  - {x: 3, y: 0, z: -7.25}
-  - {x: 2.75, y: 3, z: -7.25}
-  - {x: 2.75, y: 0, z: -7.25}
-  - {x: 3, y: 0, z: -7}
-  - {x: 3, y: 0, z: 0}
-  - {x: 2.75, y: 0, z: -7}
-  - {x: 2.75, y: 0, z: 0}
-  - {x: 3, y: 0, z: 0}
-  - {x: 3, y: 3, z: 0}
-  - {x: 2.75, y: 0, z: 0}
-  - {x: 2.75, y: 3, z: 0}
-  - {x: 0, y: 3, z: -7}
-  - {x: 0, y: 3, z: 0}
-  - {x: 0.25, y: 3, z: -7}
-  - {x: 0.25, y: 3, z: 0}
-  - {x: 0, y: 3, z: 0}
-  - {x: 0, y: 0, z: 0}
-  - {x: 0.25, y: 3, z: 0}
-  - {x: 0.25, y: 0, z: 0}
-  - {x: 0, y: 0, z: 0}
-  - {x: 0, y: 0, z: -7}
-  - {x: 0.25, y: 0, z: 0}
-  - {x: 0.25, y: 0, z: -7}
-  - {x: 0, y: 0, z: -7.25}
-  - {x: 0, y: 3, z: -7.25}
-  - {x: 0.25, y: 0, z: -7.25}
-  - {x: 0.25, y: 3, z: -7.25}
-  - {x: -3.5, y: 3, z: -7}
-  - {x: 0, y: 3, z: -7}
-  - {x: -3.5, y: 3, z: -7.25}
-  - {x: 0, y: 3, z: -7.25}
-  - {x: 0, y: 3, z: -7}
-  - {x: 0, y: 0, z: -7}
-  - {x: 0, y: 3, z: -7.25}
-  - {x: 0, y: 0, z: -7.25}
-  - {x: 0, y: 0, z: -7}
-  - {x: -3.5, y: 0, z: -7}
-  - {x: 0, y: 0, z: -7.25}
-  - {x: -3.5, y: 0, z: -7.25}
-  - {x: -3.5, y: 0, z: -7}
-  - {x: -3.5, y: 3, z: -7}
-  - {x: -3.5, y: 0, z: -7.25}
-  - {x: -3.5, y: 3, z: -7.25}
-  - {x: 3, y: 3, z: -7}
-  - {x: 6.5, y: 3, z: -7}
-  - {x: 3, y: 3, z: -7.25}
-  - {x: 6.5, y: 3, z: -7.25}
-  - {x: 6.5, y: 3, z: -7}
-  - {x: 6.5, y: 0, z: -7}
-  - {x: 6.5, y: 3, z: -7.25}
-  - {x: 6.5, y: 0, z: -7.25}
-  - {x: 6.5, y: 0, z: -7}
-  - {x: 3, y: 0, z: -7}
-  - {x: 6.5, y: 0, z: -7.25}
-  - {x: 3, y: 0, z: -7.25}
-  - {x: 3, y: 0, z: -7}
-  - {x: 3, y: 3, z: -7}
-  - {x: 3, y: 0, z: -7.25}
-  - {x: 3, y: 3, z: -7.25}
-  - {x: 6.5, y: 3, z: -10}
-  - {x: -3.5, y: 3, z: -10}
-  - {x: 6.5, y: 3, z: -9.75}
-  - {x: -3.5, y: 3, z: -9.75}
-  - {x: -3.5, y: 3, z: -10}
-  - {x: -3.5, y: 0, z: -10}
-  - {x: -3.5, y: 3, z: -9.75}
-  - {x: -3.5, y: 0, z: -9.75}
-  - {x: -3.5, y: 0, z: -10}
-  - {x: 6.5, y: 0, z: -10}
-  - {x: -3.5, y: 0, z: -9.75}
-  - {x: 6.5, y: 0, z: -9.75}
-  - {x: 6.5, y: 0, z: -10}
-  - {x: 6.5, y: 3, z: -10}
-  - {x: 6.5, y: 0, z: -9.75}
-  - {x: 6.5, y: 3, z: -9.75}
-  - {x: 3, y: 3, z: -7}
-  - {x: 3, y: 0, z: -7}
-  - {x: 3, y: 3, z: -7.25}
-  - {x: 3, y: 0, z: -7.25}
-  - {x: 2.75, y: 3, z: -7}
-  - {x: 3, y: 3, z: -7}
-  - {x: 2.75, y: 3, z: -7.25}
-  - {x: 3, y: 3, z: -7.25}
-  - {x: 3, y: 0, z: -7}
-  - {x: 2.75, y: 0, z: -7}
-  - {x: 3, y: 0, z: -7.25}
-  - {x: 2.75, y: 0, z: -7.25}
-  - {x: 2.75, y: 0, z: -7}
-  - {x: 2.75, y: 3, z: -7}
-  - {x: 2.75, y: 0, z: -7.25}
-  - {x: 2.75, y: 3, z: -7.25}
-  - {x: 0, y: 0, z: -7}
-  - {x: 0, y: 3, z: -7}
-  - {x: 0, y: 0, z: -7.25}
-  - {x: 0, y: 3, z: -7.25}
-  - {x: 0.25, y: 0, z: -7}
-  - {x: 0, y: 0, z: -7}
-  - {x: 0.25, y: 0, z: -7.25}
-  - {x: 0, y: 0, z: -7.25}
-  - {x: 0, y: 3, z: -7}
-  - {x: 0.25, y: 3, z: -7}
-  - {x: 0, y: 3, z: -7.25}
-  - {x: 0.25, y: 3, z: -7.25}
-  - {x: 0.25, y: 3, z: -7.25}
-  - {x: 0.25, y: 0, z: -7.25}
-  - {x: 0, y: 3, z: -7}
-  - {x: -3.5, y: 3, z: -7}
-  - {x: 0, y: 2.75, z: -7}
-  - {x: -3.5, y: 2.75, z: -7}
-  - {x: -3.5, y: 3, z: -7}
-  - {x: -3.5, y: 3, z: -10}
-  - {x: -3.5, y: 2.75, z: -7}
-  - {x: -3.5, y: 2.75, z: -10}
-  - {x: -3.5, y: 3, z: -10}
-  - {x: 6.5, y: 3, z: -10}
-  - {x: -3.5, y: 2.75, z: -10}
-  - {x: 6.5, y: 2.75, z: -10}
-  - {x: 6.5, y: 3, z: -10}
-  - {x: 6.5, y: 3, z: -7}
-  - {x: 6.5, y: 2.75, z: -10}
-  - {x: 6.5, y: 2.75, z: -7}
-  - {x: 6.5, y: 3, z: -7}
-  - {x: 3, y: 3, z: -7}
-  - {x: 6.5, y: 2.75, z: -7}
-  - {x: 3, y: 2.75, z: -7}
-  - {x: 0, y: 3, z: 0}
-  - {x: 0, y: 3, z: -7}
-  - {x: 0, y: 2.75, z: 0}
-  - {x: 0, y: 2.75, z: -7}
-  - {x: 3, y: 3, z: -7}
-  - {x: 3, y: 3, z: 0}
-  - {x: 3, y: 2.75, z: -7}
-  - {x: 3, y: 2.75, z: 0}
-  - {x: 3, y: 3, z: 0}
-  - {x: 0, y: 3, z: 0}
-  - {x: 3, y: 2.75, z: 0}
-  - {x: 0, y: 2.75, z: 0}
-  m_Textures0:
-  - {x: 0, y: 0}
-  - {x: 0.75, y: 0}
-  - {x: 0.75, y: -1.75}
-  - {x: 1.625, y: -1.75}
-  - {x: 1.625, y: -2.5}
-  - {x: -0.875, y: -2.5}
-  - {x: -0.875, y: -1.75}
-  - {x: 0, y: -1.75}
-  - {x: 0, y: -7}
-  - {x: 3.5, y: -7}
-  - {x: 3.5, y: -10}
-  - {x: -6.5, y: -10}
-  - {x: -3, y: -7}
-  - {x: -6.5, y: -7}
-  - {x: 0, y: 0}
-  - {x: -3, y: 0}
-  - {x: 0, y: 0}
-  - {x: 0, y: 0.75}
-  - {x: 5.75, y: 0}
-  - {x: 7.5, y: 0}
-  - {x: 5.75, y: 0.75}
-  - {x: 7.5, y: 0.75}
-  - {x: 0.75, y: 0}
-  - {x: 1.625, y: 0}
-  - {x: 0.75, y: 0.75}
-  - {x: 1.625, y: 0.75}
-  - {x: -1.625, y: 0}
-  - {x: 0.875, y: 0}
-  - {x: -1.625, y: 0.75}
-  - {x: 0.875, y: 0.75}
-  - {x: -0.875, y: 0}
-  - {x: 0, y: 0}
-  - {x: -0.875, y: 0.75}
-  - {x: 0, y: 0.75}
-  - {x: 0, y: 0}
-  - {x: -7, y: 0}
-  - {x: 0, y: 0.25}
-  - {x: -7, y: 0.25}
-  - {x: 0, y: 0}
-  - {x: -3, y: 0}
-  - {x: 0, y: 0.25}
-  - {x: -3, y: 0.25}
-  - {x: 7, y: 0}
-  - {x: 0, y: 0}
-  - {x: 7, y: 0.25}
-  - {x: 0, y: 0.25}
-  - {x: -7, y: 0}
-  - {x: -10, y: 0}
-  - {x: -7, y: 0.25}
-  - {x: -10, y: 0.25}
-  - {x: -3, y: 0}
-  - {x: -6.5, y: 0}
-  - {x: -3, y: 0.25}
-  - {x: -6.5, y: 0.25}
-  - {x: 6.5, y: 0}
-  - {x: -3.5, y: 0}
-  - {x: 6.5, y: 0.25}
-  - {x: -3.5, y: 0.25}
-  - {x: 10, y: 0}
-  - {x: 7, y: 0}
-  - {x: 10, y: 0.25}
-  - {x: 7, y: 0.25}
-  - {x: 3.5, y: 0}
-  - {x: 0, y: 0}
-  - {x: 3.5, y: 0.25}
-  - {x: 0, y: 0.25}
-  - {x: 3, y: 0}
-  - {x: 3, y: -7}
-  - {x: 2.75, y: 0}
-  - {x: 2.75, y: -7}
-  - {x: 0.75, y: 0.75}
-  - {x: 0.75, y: 0}
-  - {x: 0.6875, y: 0.75}
-  - {x: 0.6875, y: 0}
-  - {x: -3, y: -7}
-  - {x: -3, y: 0}
-  - {x: -2.75, y: -7}
-  - {x: -2.75, y: 0}
-  - {x: -3, y: 0}
-  - {x: -3, y: 3}
-  - {x: -2.75, y: 0}
-  - {x: -2.75, y: 3}
-  - {x: 0, y: -7}
-  - {x: 0, y: 0}
-  - {x: 0.25, y: -7}
-  - {x: 0.25, y: 0}
-  - {x: 0, y: 3}
-  - {x: 0, y: 0}
-  - {x: -0.25, y: 3}
-  - {x: -0.25, y: 0}
-  - {x: 0, y: 0}
-  - {x: 0, y: -7}
-  - {x: -0.25, y: 0}
-  - {x: -0.25, y: -7}
-  - {x: 0, y: 0}
-  - {x: 0, y: 0.75}
-  - {x: 0.0625, y: 0}
-  - {x: 0.0625, y: 0.75}
-  - {x: -3.5, y: -7}
-  - {x: 0, y: -7}
-  - {x: -3.5, y: -7.25}
-  - {x: 0, y: -7.25}
-  - {x: -7, y: 3}
-  - {x: -7, y: 0}
-  - {x: -7.25, y: 3}
-  - {x: -7.25, y: 0}
-  - {x: 0, y: -7}
-  - {x: 3.5, y: -7}
-  - {x: 0, y: -7.25}
-  - {x: 3.5, y: -7.25}
-  - {x: 7, y: 0}
-  - {x: 7, y: 3}
-  - {x: 7.25, y: 0}
-  - {x: 7.25, y: 3}
-  - {x: 3, y: -7}
-  - {x: 6.5, y: -7}
-  - {x: 3, y: -7.25}
-  - {x: 6.5, y: -7.25}
-  - {x: -7, y: 3}
-  - {x: -7, y: 0}
-  - {x: -7.25, y: 3}
-  - {x: -7.25, y: 0}
-  - {x: -6.5, y: -7}
-  - {x: -3, y: -7}
-  - {x: -6.5, y: -7.25}
-  - {x: -3, y: -7.25}
-  - {x: 7, y: 0}
-  - {x: 7, y: 3}
-  - {x: 7.25, y: 0}
-  - {x: 7.25, y: 3}
-  - {x: 6.5, y: -10}
-  - {x: -3.5, y: -10}
-  - {x: 6.5, y: -9.75}
-  - {x: -3.5, y: -9.75}
-  - {x: 10, y: 3}
-  - {x: 10, y: 0}
-  - {x: 9.75, y: 3}
-  - {x: 9.75, y: 0}
-  - {x: 3.5, y: -10}
-  - {x: -6.5, y: -10}
-  - {x: 3.5, y: -9.75}
-  - {x: -6.5, y: -9.75}
-  - {x: -10, y: 0}
-  - {x: -10, y: 3}
-  - {x: -9.75, y: 0}
-  - {x: -9.75, y: 3}
-  - {x: -7, y: 3}
-  - {x: -7, y: 0}
-  - {x: -7.25, y: 3}
-  - {x: -7.25, y: 0}
-  - {x: 2.75, y: -7}
-  - {x: 3, y: -7}
-  - {x: 2.75, y: -7.25}
-  - {x: 3, y: -7.25}
-  - {x: -3, y: -7}
-  - {x: -2.75, y: -7}
-  - {x: -3, y: -7.25}
-  - {x: -2.75, y: -7.25}
-  - {x: 1.75, y: 0}
-  - {x: 1.75, y: 0.75}
-  - {x: 1.8125, y: 0}
-  - {x: 1.8125, y: 0.75}
-  - {x: 7, y: 0}
-  - {x: 7, y: 3}
-  - {x: 7.25, y: 0}
-  - {x: 7.25, y: 3}
-  - {x: -0.25, y: -7}
-  - {x: 0, y: -7}
-  - {x: -0.25, y: -7.25}
-  - {x: 0, y: -7.25}
-  - {x: 0, y: -7}
-  - {x: 0.25, y: -7}
-  - {x: 0, y: -7.25}
-  - {x: 0.25, y: -7.25}
-  - {x: 5.6875, y: 0.75}
-  - {x: 5.6875, y: 0}
-  - {x: 0, y: 3}
-  - {x: 3.5, y: 3}
-  - {x: 0, y: 2.75}
-  - {x: 3.5, y: 2.75}
-  - {x: 7, y: 3}
-  - {x: 10, y: 3}
-  - {x: 7, y: 2.75}
-  - {x: 10, y: 2.75}
-  - {x: -3.5, y: 3}
-  - {x: 6.5, y: 3}
-  - {x: -3.5, y: 2.75}
-  - {x: 6.5, y: 2.75}
-  - {x: -10, y: 3}
-  - {x: -7, y: 3}
-  - {x: -10, y: 2.75}
-  - {x: -7, y: 2.75}
-  - {x: -6.5, y: 3}
-  - {x: -3, y: 3}
-  - {x: -6.5, y: 2.75}
-  - {x: -3, y: 2.75}
-  - {x: 0, y: 3}
-  - {x: 7, y: 3}
-  - {x: 0, y: 2.75}
-  - {x: 7, y: 2.75}
-  - {x: -7, y: 3}
-  - {x: 0, y: 3}
-  - {x: -7, y: 2.75}
-  - {x: 0, y: 2.75}
-  - {x: -3, y: 3}
-  - {x: 0, y: 3}
-  - {x: -3, y: 2.75}
-  - {x: 0, y: 2.75}
-  m_Textures2: []
-  m_Textures3: []
-  m_Tangents:
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: -1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: 0, y: 0, z: 1, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  - {x: -1, y: 0, z: 0, w: -1}
-  m_Colors: []
-  m_UnwrapParameters:
-    m_HardAngle: 88
-    m_PackMargin: 20
-    m_AngleError: 8
-    m_AreaError: 15
-  m_PreserveMeshAssetOnDestroy: 0
-  assetGuid: 
-  m_Mesh: {fileID: 0}
-  m_VersionIndex: 624
-  m_IsSelectable: 1
-  m_SelectedFaces: 
-  m_SelectedEdges: []
-  m_SelectedVertices: 
---- !u!114 &4502925545583902515
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5406731352137547262}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bb977b126bc1b4f15813dcf9da9bb600, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Points:
-  - {x: 0, y: 0, z: 0}
-  - {x: 3, y: 0, z: 0}
-  - {x: 3, y: 0, z: -7}
-  - {x: 6.5, y: 0, z: -7}
-  - {x: 6.5, y: 0, z: -10}
-  - {x: -3.5, y: 0, z: -10}
-  - {x: -3.5, y: 0, z: -7}
-  - {x: 0, y: 0, z: -7}
-  m_Extrude: 3
-  m_EditMode: 0
-  m_FlipNormals: 1
-  isOnGrid: 1
---- !u!23 &5789403625473202347
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5406731352137547262}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 5286def77a8bc454c85306f41471fe12, type: 2}
-  - {fileID: 2100000, guid: 86d8460c276ddfa4993fffe0c2069fbf, type: 2}
-  - {fileID: 2100000, guid: 4341072563c50c6408f10da8e6c5a74a, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 2
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &2171908539241877793
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5406731352137547262}
-  m_Mesh: {fileID: 0}
---- !u!64 &557849540726782993
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5406731352137547262}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 0
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 0}
 --- !u!1 &5425986583387613393
 GameObject:
   m_ObjectHideFlags: 0
@@ -22895,11 +18237,9 @@ Transform:
   - {fileID: 6932092010245188186}
   - {fileID: 1848267259333849040}
   - {fileID: 8855303446288041816}
-  - {fileID: 5150440261622003823}
   - {fileID: 5222823971767531099}
   - {fileID: 6121652731587482930}
   - {fileID: 8619460394348367459}
-  - {fileID: 5725746646303265768}
   - {fileID: 3558575935003476889}
   - {fileID: 3886475925618790128}
   - {fileID: 1150841271006929008}
@@ -22911,129 +18251,24 @@ Transform:
   - {fileID: 3613562461635135955}
   - {fileID: 5451849440082503622}
   - {fileID: 9154472980391502370}
-  - {fileID: 5618225657682963032}
-  - {fileID: 8410048339011494534}
+  - {fileID: 6716070348506130186}
+  - {fileID: 4359733485581057091}
+  - {fileID: 2713103086920165273}
+  - {fileID: 5541001624683325654}
+  - {fileID: 5376802135143472337}
+  - {fileID: 3851837083704231181}
+  - {fileID: 2509577294056235396}
+  - {fileID: 6472517078032918682}
+  - {fileID: 952352930451674970}
+  - {fileID: 9215774235014439301}
+  - {fileID: 7795951364390880456}
+  - {fileID: 1427238947013139019}
+  - {fileID: 4955633922775826253}
+  - {fileID: 7737223000036729107}
+  - {fileID: 7303546339382734997}
+  - {fileID: 1489778585662590129}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5695415639912179839
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8903455986912562286}
-  - component: {fileID: 3700014365395380722}
-  - component: {fileID: 4126458168614692973}
-  - component: {fileID: 1427888083117997908}
-  - component: {fileID: 7809783318262496173}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (3)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8903455986912562286
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5695415639912179839}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.429451, y: -1.9886248, z: -1.0542908}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5618225657682963032}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &3700014365395380722
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5695415639912179839}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &4126458168614692973
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5695415639912179839}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &1427888083117997908
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5695415639912179839}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &7809783318262496173
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5695415639912179839}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
 --- !u!1 &5871170536490094845
 GameObject:
   m_ObjectHideFlags: 0
@@ -23153,164 +18388,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _maxHealth: 0
---- !u!1 &5889791316916625342
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4605071679686218372}
-  - component: {fileID: 8363057116339486259}
-  - component: {fileID: 3757837544312425956}
-  - component: {fileID: 4087211654596314714}
-  - component: {fileID: 5332532956360844209}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4605071679686218372
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5889791316916625342}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.5552063, y: -2.5216248, z: -1.2497559}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5618225657682963032}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &8363057116339486259
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5889791316916625342}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &3757837544312425956
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5889791316916625342}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &4087211654596314714
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5889791316916625342}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &5332532956360844209
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5889791316916625342}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
---- !u!1 &5895178004901049106
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8410048339011494534}
-  m_Layer: 0
-  m_Name: Crate Pile  (4)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8410048339011494534
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5895178004901049106}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 130.95, y: -2.6753752, z: -4.69}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5135478871214102639}
-  - {fileID: 2423995836372801272}
-  - {fileID: 1881151709685128449}
-  - {fileID: 2460145219091655892}
-  - {fileID: 8273136066350937025}
-  - {fileID: 5834478663742057848}
-  - {fileID: 772438186797008709}
-  - {fileID: 8199618758389594329}
-  m_Father: {fileID: 7716199184528678064}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5972800464546564299
 GameObject:
   m_ObjectHideFlags: 0
@@ -24349,7 +19426,7 @@ Transform:
   m_GameObject: {fileID: 6342244527820411709}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 127.91043, y: -5.7048264, z: -27.230133}
+  m_LocalPosition: {x: 127.91043, y: -5.7048264, z: -30.2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -25089,125 +20166,6 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
---- !u!1 &6705789449564144467
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6643897596989150801}
-  - component: {fileID: 4669262822416748893}
-  - component: {fileID: 1660368951112397549}
-  - component: {fileID: 3720588092397051000}
-  - component: {fileID: 1410350334480820653}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (4)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6643897596989150801
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6705789449564144467}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.451065, y: -1.3646247, z: -1.0705566}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5618225657682963032}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &4669262822416748893
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6705789449564144467}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &1660368951112397549
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6705789449564144467}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &3720588092397051000
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6705789449564144467}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &1410350334480820653
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6705789449564144467}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
 --- !u!1 &6804706493918578083
 GameObject:
   m_ObjectHideFlags: 0
@@ -28344,125 +23302,6 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
---- !u!1 &7874279471170106695
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1881151709685128449}
-  - component: {fileID: 3859315362155398564}
-  - component: {fileID: 1598674106725021936}
-  - component: {fileID: 1144366769465129470}
-  - component: {fileID: 7634554237056087383}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1881151709685128449
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7874279471170106695}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.3652878, y: -1.8236248, z: 0.12814331}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8410048339011494534}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &3859315362155398564
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7874279471170106695}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &1598674106725021936
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7874279471170106695}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &1144366769465129470
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7874279471170106695}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &7634554237056087383
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7874279471170106695}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
 --- !u!1 &8355727105305175145
 GameObject:
   m_ObjectHideFlags: 0
@@ -28695,125 +23534,6 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8356729152974723477}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _maxHealth: 0
---- !u!1 &8483921359539193725
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1463767763375590934}
-  - component: {fileID: 1407778834835818311}
-  - component: {fileID: 3043643619433763281}
-  - component: {fileID: 3391617465635701063}
-  - component: {fileID: 5641147345527997662}
-  m_Layer: 0
-  m_Name: CrateV1_Closed_LP (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1463767763375590934
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8483921359539193725}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071069, y: -0, z: -0, w: 0.7071067}
-  m_LocalPosition: {x: -3.48378, y: -2.4486248, z: -0.12988281}
-  m_LocalScale: {x: 37, y: 51, z: 25}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5618225657682963032}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &1407778834835818311
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8483921359539193725}
-  m_Mesh: {fileID: -5495902117074765545, guid: 8d8afed68b3fe8048a7466c978419a25, type: 3}
---- !u!23 &3043643619433763281
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8483921359539193725}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9098964d0da8ae048bacac761b0b26b4, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &3391617465635701063
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8483921359539193725}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.021289678, y: 0.02, z: 0.022925353}
-  m_Center: {x: -0.000070645474, y: -2.0785884e-17, z: 0.0014626766}
---- !u!114 &5641147345527997662
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8483921359539193725}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c74c2e8c40cf69e47893c14ddad267ed, type: 3}
@@ -30624,7 +25344,7 @@ Transform:
   m_GameObject: {fileID: 8929760833036585970}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 120.91043, y: -5.7048264, z: -23.81015}
+  m_LocalPosition: {x: 120.91043, y: -5.7048264, z: -26.69}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -32536,6 +27256,613 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 794964080054324425}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &939125660309252228
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 2634726881836143546, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_Name
+      value: Stem(attack) (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 145.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.47
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -50.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7663ac9099e96704fa54fc940fbc2e16, type: 3}
+--- !u!4 &2509577294056235396 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+    type: 3}
+  m_PrefabInstance: {fileID: 939125660309252228}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1922975348655016973
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 2634726881836143546, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_Name
+      value: Stem(attack)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 141.1441
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -60.119263
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7663ac9099e96704fa54fc940fbc2e16, type: 3}
+--- !u!4 &3851837083704231181 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+    type: 3}
+  m_PrefabInstance: {fileID: 1922975348655016973}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2097064903702240653
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 131.38043
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -59.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2580993177325062120, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2580993177325062120, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3327735217203135166, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_Name
+      value: StoryBeatProgressionTrigger
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3141d4d47efc9bf4391e992a74ca4910, type: 3}
+--- !u!4 &1427238947013139019 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+    type: 3}
+  m_PrefabInstance: {fileID: 2097064903702240653}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2516616633354264154
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 2634726881836143546, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_Name
+      value: Stem(attack) (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 118.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -26.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7663ac9099e96704fa54fc940fbc2e16, type: 3}
+--- !u!4 &952352930451674970 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+    type: 3}
+  m_PrefabInstance: {fileID: 2516616633354264154}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2605476938215246472
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 3495992618392602169, guid: d06ea0c4383c7c6408954aa706934f81,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3.0000002
+      objectReference: {fileID: 0}
+    - target: {fileID: 3495992618392602169, guid: d06ea0c4383c7c6408954aa706934f81,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 140.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 3495992618392602169, guid: d06ea0c4383c7c6408954aa706934f81,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 3495992618392602169, guid: d06ea0c4383c7c6408954aa706934f81,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -80.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3495992618392602169, guid: d06ea0c4383c7c6408954aa706934f81,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3495992618392602169, guid: d06ea0c4383c7c6408954aa706934f81,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3495992618392602169, guid: d06ea0c4383c7c6408954aa706934f81,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3495992618392602169, guid: d06ea0c4383c7c6408954aa706934f81,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3495992618392602169, guid: d06ea0c4383c7c6408954aa706934f81,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3495992618392602169, guid: d06ea0c4383c7c6408954aa706934f81,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3495992618392602169, guid: d06ea0c4383c7c6408954aa706934f81,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6952257969339963696, guid: d06ea0c4383c7c6408954aa706934f81,
+        type: 3}
+      propertyPath: m_Name
+      value: Generator
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d06ea0c4383c7c6408954aa706934f81, type: 3}
+--- !u!4 &1489778585662590129 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3495992618392602169, guid: d06ea0c4383c7c6408954aa706934f81,
+    type: 3}
+  m_PrefabInstance: {fileID: 2605476938215246472}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3711717035714151399
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 133958881903128052, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_Name
+      value: Hall (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 137.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -43.72
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e2ff6917c09f07a4183ea1b72f332930, type: 3}
+--- !u!4 &4359733485581057091 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+    type: 3}
+  m_PrefabInstance: {fileID: 3711717035714151399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4893125695421650802
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 133958881903128052, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_Name
+      value: Hall (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 127.88
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e2ff6917c09f07a4183ea1b72f332930, type: 3}
+--- !u!4 &5541001624683325654 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+    type: 3}
+  m_PrefabInstance: {fileID: 4893125695421650802}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4894136233129266632
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 2634726881836143546, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_Name
+      value: Stem(attack) (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 118.289734
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.62
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.15094
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7663ac9099e96704fa54fc940fbc2e16, type: 3}
+--- !u!4 &7795951364390880456 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+    type: 3}
+  m_PrefabInstance: {fileID: 4894136233129266632}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5070636082740918063
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -32614,6 +27941,243 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
     type: 3}
   m_PrefabInstance: {fileID: 5070636082740918063}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5204253772426847294
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 191126141287069935, guid: 0409356e3e3db084598bd5d2e4830916,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 129.7702
+      objectReference: {fileID: 0}
+    - target: {fileID: 191126141287069935, guid: 0409356e3e3db084598bd5d2e4830916,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 191126141287069935, guid: 0409356e3e3db084598bd5d2e4830916,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 34.10074
+      objectReference: {fileID: 0}
+    - target: {fileID: 191126141287069935, guid: 0409356e3e3db084598bd5d2e4830916,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 191126141287069935, guid: 0409356e3e3db084598bd5d2e4830916,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 191126141287069935, guid: 0409356e3e3db084598bd5d2e4830916,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 191126141287069935, guid: 0409356e3e3db084598bd5d2e4830916,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 191126141287069935, guid: 0409356e3e3db084598bd5d2e4830916,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 191126141287069935, guid: 0409356e3e3db084598bd5d2e4830916,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 191126141287069935, guid: 0409356e3e3db084598bd5d2e4830916,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3128038944435077486, guid: 0409356e3e3db084598bd5d2e4830916,
+        type: 3}
+      propertyPath: _sceneToLoadIndex
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5583898241122978966, guid: 0409356e3e3db084598bd5d2e4830916,
+        type: 3}
+      propertyPath: m_Name
+      value: Hatch
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0409356e3e3db084598bd5d2e4830916, type: 3}
+--- !u!4 &5376802135143472337 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 191126141287069935, guid: 0409356e3e3db084598bd5d2e4830916,
+    type: 3}
+  m_PrefabInstance: {fileID: 5204253772426847294}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5337088686232434827
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 131.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -42.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2580993177325062120, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2580993177325062120, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3327735217203135166, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_Name
+      value: StoryBeatProgressionTrigger (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3141d4d47efc9bf4391e992a74ca4910, type: 3}
+--- !u!4 &4955633922775826253 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+    type: 3}
+  m_PrefabInstance: {fileID: 5337088686232434827}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5782269363559065733
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 2634726881836143546, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_Name
+      value: Stem(attack) (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 111.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -14.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7663ac9099e96704fa54fc940fbc2e16, type: 3}
+--- !u!4 &9215774235014439301 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+    type: 3}
+  m_PrefabInstance: {fileID: 5782269363559065733}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5907172835848340375
 PrefabInstance:
@@ -32694,6 +28258,80 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 5907172835848340375}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5923937881710188718
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 133958881903128052, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_Name
+      value: Hall (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 130.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -40.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e2ff6917c09f07a4183ea1b72f332930, type: 3}
+--- !u!4 &6716070348506130186 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+    type: 3}
+  m_PrefabInstance: {fileID: 5923937881710188718}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7171899107678440609
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -32772,4 +28410,320 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
     type: 3}
   m_PrefabInstance: {fileID: 7171899107678440609}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7328751301941372629
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 127.2919
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -25.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2580993177325062120, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2580993177325062120, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3327735217203135166, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_Name
+      value: StoryBeatProgressionTrigger (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3141d4d47efc9bf4391e992a74ca4910, type: 3}
+--- !u!4 &7737223000036729107 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+    type: 3}
+  m_PrefabInstance: {fileID: 7328751301941372629}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7750624155527903059
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 127.24785
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2580993177325062120, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2580993177325062120, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3327735217203135166, guid: 3141d4d47efc9bf4391e992a74ca4910,
+        type: 3}
+      propertyPath: m_Name
+      value: StoryBeatProgressionTrigger (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3141d4d47efc9bf4391e992a74ca4910, type: 3}
+--- !u!4 &7303546339382734997 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1068715586953824198, guid: 3141d4d47efc9bf4391e992a74ca4910,
+    type: 3}
+  m_PrefabInstance: {fileID: 7750624155527903059}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8505401329357250970
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 2634726881836143546, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_Name
+      value: Stem(attack) (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 140.54
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -43.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7663ac9099e96704fa54fc940fbc2e16, type: 3}
+--- !u!4 &6472517078032918682 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3448559462593612032, guid: 7663ac9099e96704fa54fc940fbc2e16,
+    type: 3}
+  m_PrefabInstance: {fileID: 8505401329357250970}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8551412700557341002
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7716199184528678064}
+    m_Modifications:
+    - target: {fileID: 5983692263960581843, guid: dce5f02bd36f07e47a53d71da8244751,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 127.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5983692263960581843, guid: dce5f02bd36f07e47a53d71da8244751,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.709
+      objectReference: {fileID: 0}
+    - target: {fileID: 5983692263960581843, guid: dce5f02bd36f07e47a53d71da8244751,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 5983692263960581843, guid: dce5f02bd36f07e47a53d71da8244751,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5983692263960581843, guid: dce5f02bd36f07e47a53d71da8244751,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5983692263960581843, guid: dce5f02bd36f07e47a53d71da8244751,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5983692263960581843, guid: dce5f02bd36f07e47a53d71da8244751,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5983692263960581843, guid: dce5f02bd36f07e47a53d71da8244751,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5983692263960581843, guid: dce5f02bd36f07e47a53d71da8244751,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5983692263960581843, guid: dce5f02bd36f07e47a53d71da8244751,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6915856786845815004, guid: dce5f02bd36f07e47a53d71da8244751,
+        type: 3}
+      propertyPath: m_Name
+      value: LongHall (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dce5f02bd36f07e47a53d71da8244751, type: 3}
+--- !u!4 &2713103086920165273 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5983692263960581843, guid: dce5f02bd36f07e47a53d71da8244751,
+    type: 3}
+  m_PrefabInstance: {fileID: 8551412700557341002}
   m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
Updated the chase sequence prefabs with one ways on the end of the offshoots, ending hatch, crate piles to block the player,  normal attacks in the offshoots, and triggers for chase attack when they are finished by engineering. https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32?assignee=631f4a57978dae24dc064a89&selectedIssue=LV-1002 