### PR TITLE
beta-eng-Tweening-Warning-in-regards-to-environmental-lights-LV-984

### DIFF
--- a/Assets/General/Scripts/Story/RandomizedAnimation.cs
+++ b/Assets/General/Scripts/Story/RandomizedAnimation.cs
@@ -52,6 +52,8 @@ public class RandomizedAnimation : MonoBehaviour
     /// </summary>
     private void StartRandomDelay()
     {
+        if (!gameObject.activeInHierarchy) return;
+
         Tween.Delay(this, Random.Range(_minAnimationDelay, _maxAnimationDelay), DetermineNextAnimation);
     }
 


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?assignee=6318bb796856bdd60aa045de&selectedIssue=LV-984
Tiny bug fix to remove a warning that would occur in the console
Code Review Estimation <1 Minute
In Engine Estimation <3 minutes
Where the warning would occur: Completion of any maze. When the maze switches from one to another. There are no warnings now