### PR TITLE
beta-eng-Can-use-healing-packs-at-full-health-LV-987

### DIFF
--- a/Assets/GameAssets/UI/UIScripts/WorldSpace Popups.cs
+++ b/Assets/GameAssets/UI/UIScripts/WorldSpace Popups.cs
@@ -48,6 +48,7 @@ public class WorldSpacePopups : MonoBehaviour
 
     private void Awake()
     {
+        _objectSpriteReference = GetComponent<SpriteRenderer>();
         StartCoroutine(FindPlayer());
     }
 
@@ -93,8 +94,6 @@ public class WorldSpacePopups : MonoBehaviour
 
         _playerCamera = PlayerFunctionalityCore.Instance.PlayerCamera.transform.Find("Main Camera").GetComponent<Camera>();
         _playerReference = PlayerFunctionalityCore.Instance.transform.GetChild(1).gameObject;
-
-        _objectSpriteReference = GetComponent<SpriteRenderer>();
     }
 
     /// <summary>

--- a/Assets/GameAssets/World/WorldScripts/Interactables/HealthPackInteractable.cs
+++ b/Assets/GameAssets/World/WorldScripts/Interactables/HealthPackInteractable.cs
@@ -18,12 +18,62 @@ public class HealthPackInteractable : MonoBehaviour, IPlayerInteractable
     [SerializeField] private int _healthRestored = 20;
     [SerializeField] private int _numUses = 3;
 
+    private WorldSpacePopups _interactPopup;
+    private bool _canInteract = false;
+
+    /// <summary>
+    /// Performs initial setup
+    /// </summary>
+    private void Start()
+    {
+        SubscribeToEvents();
+        SetInitialVariables();
+    }
+
+    /// <summary>
+    /// Cleans up anything after destruction
+    /// </summary>
+    private void OnDestroy()
+    {
+        UnsubscribeToEvents();
+    }
+
+    /// <summary>
+    /// Sets any variables to what they should be on start
+    /// </summary>
+    private void SetInitialVariables()
+    {
+        _interactPopup = GetComponentInChildren<WorldSpacePopups>();
+        UpdateInteractablePopupToggle();
+    }
+
+    /// <summary>
+    /// Subscribes to any needed events
+    /// </summary>
+    private void SubscribeToEvents()
+    {
+        PlayerManager.Instance.GetOnPlayerHealthChangeEvent().AddListener(UpdateInteractability);
+    }
+
+    /// <summary>
+    /// Unsubscribes to any subscribed events
+    /// </summary>
+    private void UnsubscribeToEvents()
+    {
+        PlayerManager.Instance.GetOnPlayerHealthChangeEvent().RemoveListener(UpdateInteractability);
+    }
+
     /// <summary>
     /// An inherited method that triggers when the object is interacted with.
     /// Heals the player for a certain amount of health
     /// </summary>
     public void OnInteractedByPlayer()
     {
+        if(!_canInteract)
+        {
+            return;
+        }
+
         PlayerManager.Instance.OnInvokePlayerHealEvent(_healthRestored);
         _numUses--;
 
@@ -31,5 +81,24 @@ public class HealthPackInteractable : MonoBehaviour, IPlayerInteractable
         {
             Destroy(gameObject);
         }
+    }
+
+    /// <summary>
+    /// Updates the interactability of the associated world space popup
+    /// </summary>
+    /// <param name="percentHealth"> The percent health variable from the event </param>
+    /// <param name="currentHealth"> The current health variable from the event </param>
+    private void UpdateInteractability(float percentHealth, float currentHealth)
+    {
+        _canInteract = percentHealth < 1;
+        UpdateInteractablePopupToggle();
+    }
+
+    /// <summary>
+    /// Updates the status of the interactable popup
+    /// </summary>
+    private void UpdateInteractablePopupToggle()
+    {
+        _interactPopup.TogglePopUp(_canInteract);
     }
 }


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?assignee=6318bb796856bdd60aa045de&selectedIssue=LV-987

Updated the health packs to change intractability based on if the player is full health or not. Best tested in the above deck scene. You shouldn't be able to use the health packs. Then open the debug menu (its bound to c) and inflict damage to yourself (you have to set the amount of damage first) Health packs heal 20 health currently, so if you inflict 30 damage you can use it twice.
Code Review Estimation: <3 minutes
Engine Review Estimation: <3 minutes