### PR TITLE
beta-eng-Harpoon-Impact-VFX-Functionality-LV-1137

### DIFF
--- a/Assets/GameAssets/Player/PlayerScripts/Harpoon/HarpoonDamage.cs
+++ b/Assets/GameAssets/Player/PlayerScripts/Harpoon/HarpoonDamage.cs
@@ -14,17 +14,21 @@ using UnityEngine;
 public class HarpoonDamage : BaseDamage
 {
     /// <summary>
+    /// Overrides the on trigger enter to also check for Vfx
+    /// </summary>
+    /// <param name="col"> The collider we contacted </param>
+    protected override void OnTriggerEnter(Collider col)
+    {
+        CheckForVfxObject(col.gameObject);
+        base.OnTriggerEnter(col);
+    }
+
+    /// <summary>
     /// Applies damage to the recipient as long as it is not the player
     /// </summary>
-    /// <param name="damageRecipient"></param>
+    /// <param name="damageRecipient"> The target to deal damage to</param>
     public override void ApplyDamage(GameObject damageRecipient)
     {
-        //Checks if its an object to spawn vfx on
-        if (damageRecipient.TryGetComponent<HarpoonHitVfxSpawner>(out HarpoonHitVfxSpawner harpoonHitVfx))
-        {
-            harpoonHitVfx.HarpoonHit(transform);
-        }
-
         // Avoids damaging the player
         if (damageRecipient.TryGetComponent<PlayerHealth>(out PlayerHealth playerHealth)
             || !damageRecipient.CompareTag("Enemy")) 
@@ -32,5 +36,18 @@ public class HarpoonDamage : BaseDamage
             return;
         }
         base.ApplyDamage(damageRecipient);
+    }
+
+    /// <summary>
+    /// Checks if the object should spawn Vfx on collision
+    /// </summary>
+    /// <param name="target"> The target for collision </param>
+    private void CheckForVfxObject(GameObject target)
+    {
+        //Checks if its an object to spawn vfx on
+        if (target.TryGetComponent<HarpoonHitVfxSpawner>(out HarpoonHitVfxSpawner harpoonHitVfx))
+        {
+            harpoonHitVfx.HarpoonHit(transform);
+        }
     }
 }

--- a/Assets/GameAssets/Player/PlayerScripts/Harpoon/HarpoonDamage.cs
+++ b/Assets/GameAssets/Player/PlayerScripts/Harpoon/HarpoonDamage.cs
@@ -19,8 +19,15 @@ public class HarpoonDamage : BaseDamage
     /// <param name="damageRecipient"></param>
     public override void ApplyDamage(GameObject damageRecipient)
     {
+        //Checks if its an object to spawn vfx on
+        if (damageRecipient.TryGetComponent<HarpoonHitVfxSpawner>(out HarpoonHitVfxSpawner harpoonHitVfx))
+        {
+            harpoonHitVfx.HarpoonHit(transform);
+        }
+
         // Avoids damaging the player
-        if (damageRecipient.TryGetComponent<PlayerHealth>(out PlayerHealth playerHealth) || !damageRecipient.CompareTag("Enemy"))
+        if (damageRecipient.TryGetComponent<PlayerHealth>(out PlayerHealth playerHealth)
+            || !damageRecipient.CompareTag("Enemy")) 
         {
             return;
         }

--- a/Assets/GameAssets/Player/PlayerVFX/VFXHarpoonSplintersDeck.prefab
+++ b/Assets/GameAssets/Player/PlayerVFX/VFXHarpoonSplintersDeck.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 3534484816514161111}
   - component: {fileID: 7412016873501224740}
   - component: {fileID: 3994769175268358782}
+  - component: {fileID: 8883304008378043955}
   m_Layer: 0
   m_Name: VFXHarpoonSplintersDeck
   m_TagString: Untagged
@@ -29,7 +30,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
@@ -4900,3 +4901,17 @@ ParticleSystemRenderer:
   m_MeshWeighting2: 1
   m_MeshWeighting3: 1
   m_MaskInteraction: 0
+--- !u!114 &8883304008378043955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2068631312327826608}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2ecb38d543f7de49937a91c21b62c7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _isMoveableVfx: 0
+  _vfxSpeed: 2

--- a/Assets/General/Prefabs/Managers/UniversalManagers/MainUniversalManagers/VfxManager.prefab
+++ b/Assets/General/Prefabs/Managers/UniversalManagers/MainUniversalManagers/VfxManager.prefab
@@ -63,11 +63,11 @@ MonoBehaviour:
     _poolingAmount: 5
     _vfxDurationType: 0
     _fixedDuration: 0
-  - _vfxName: '-'
-    _vfxObject: {fileID: 8544335786728863607, guid: 29c59d25c074ab144be794768677f2fc,
+  - _vfxName: WoodChips
+    _vfxObject: {fileID: 2068631312327826608, guid: 6e3a6aa3db95b2d4f9fbfeaf30f7cc1d,
       type: 3}
     _poolingAmount: 5
-    _vfxDurationType: 2
+    _vfxDurationType: 0
     _fixedDuration: 0
   - _vfxName: MetalSparks
     _vfxObject: {fileID: 5469250826509107533, guid: c642fe85bc367b04ca8329825a13919c,

--- a/Assets/General/Scenes/GeneralTestGyms/HitVfx.unity.meta
+++ b/Assets/General/Scenes/GeneralTestGyms/HitVfx.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3b4cf370f5127bf44ad842e622404022
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/General/Scripts/UniversalFunctions/HarpoonHitVfxSpawner.cs
+++ b/Assets/General/Scripts/UniversalFunctions/HarpoonHitVfxSpawner.cs
@@ -1,0 +1,52 @@
+/*********************************************************************************************************************
+// File Name :         HarpoonHitVfxSpawner.cs
+// Author :            Ryan Swanson
+// Creation Date :     02/23/2025
+//
+// Brief Description : Manages the VFX of hitting the environment with a harpoon
+*********************************************************************************************************************/
+using UnityEngine;
+
+/// <summary>
+/// The types of environment that can be hit by a harpoon
+/// </summary>
+public enum HarpoonEnvironmentHitTypes
+{
+    Wood,
+    Metal
+}
+
+/// <summary>
+/// Spawns vfx when hit by a harpoon
+/// </summary>
+public class HarpoonHitVfxSpawner : MonoBehaviour
+{
+    [SerializeField] private HarpoonEnvironmentHitTypes _hitType;
+
+    private SpecificVisualEffect _associatedEffect;
+
+    /// <summary>
+    /// Assigns the associated effect based on the environment type
+    /// </summary>
+    public void Start()
+    {
+        switch (_hitType)
+        {
+            case (HarpoonEnvironmentHitTypes.Wood):
+                _associatedEffect = VfxManager.Instance.GetWoodenSparksVfx();
+                break;
+            case (HarpoonEnvironmentHitTypes.Metal):
+                _associatedEffect = VfxManager.Instance.GetMetalSparksVfx();
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Called by the harpoon on
+    /// </summary>
+    /// <param name="harpoonOrientation"> The world transform of the harpoon </param>
+    public void HarpoonHit(Transform harpoonOrientation)
+    {
+        _associatedEffect.PlayNextVfxInPool(harpoonOrientation.transform.position,harpoonOrientation.transform.rotation);
+    }
+}

--- a/Assets/General/Scripts/UniversalFunctions/HarpoonHitVfxSpawner.cs.meta
+++ b/Assets/General/Scripts/UniversalFunctions/HarpoonHitVfxSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 762e80a5332e1484086f66a57284eb2f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?assignee=6318bb796856bdd60aa045de&selectedIssue=LV-1137

There was an old system in place by Mark, but it didn't work quite how I wanted it to. It required health to be on any surface that is hit. It also spawned the vfx at the center of the object, not the point of collision. I couldn't rework it to get the second point working, so instead here's a new system. Designers can simply pick from a dropdown of what type of object we are colliding with. Before someone asks, yes there is wood splinter vfx, but they are tiny so they are hard to see.
To test this go into the new scene. I added 2 cubes for you to shoot. One is wood the other is metal. Ignore the other errors in this scene. Not part of this task.

Code Review Estimation: <3 minutes
In Engine Review Estimation: <4 minutes