### PR TITLE
Beta eng open pause and settings loads maze lv 1477

### DIFF
--- a/Assets/General/Prefabs/PlayerHUDCanvas.prefab
+++ b/Assets/General/Prefabs/PlayerHUDCanvas.prefab
@@ -386,7 +386,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8083432232435087493}
+  - {fileID: 6357386270812014923}
   - {fileID: 3743909833683724276}
   - {fileID: 1947120736357680081}
   - {fileID: 6037653829352807890}
@@ -1137,7 +1137,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5909011039722504716}
-  - {fileID: 6357386270812014923}
+  - {fileID: 8083432232435087493}
   - {fileID: 3434195639896372223}
   - {fileID: 8446700979928095811}
   - {fileID: 3169763230573608484}
@@ -1463,7 +1463,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6482704325034278035}
+  m_Father: {fileID: 3434195639896372223}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -5333,7 +5333,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3434195639896372223}
+  m_Father: {fileID: 6482704325034278035}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}

--- a/Assets/General/Scripts/Maze/MazeSubSceneManager.cs
+++ b/Assets/General/Scripts/Maze/MazeSubSceneManager.cs
@@ -279,7 +279,8 @@ public class MazeSubSceneManager : MonoBehaviour
     /// <param name="scene">The scene unloaded</param>
     private void OnSceneUnloaded(Scene scene)
     {
-        if ((scene.buildIndex == 4 || scene.buildIndex == 6) && _currentMaze < AframaxSceneManager.Instance.MazeAdditiveSceneIndices.Count-1)
+        if ((scene.buildIndex == 4 || scene.buildIndex == 5 || scene.buildIndex == 6)
+            && _currentMaze < AframaxSceneManager.Instance.MazeAdditiveSceneIndices.Count-1)
         {
             PreLoadMazeScene(_currentMaze+1);
         }


### PR DESCRIPTION
The scene should no longer load in the next maze on top of the current maze when going to another subscene
IE: Settings or Quit

There might be errors beyond the first maze, but I'm exhausted and don't have the brain power to be on my laptop