### PR TITLE
gold-eng-Healing-VFX-Functionality-LV-1595

### DIFF
--- a/Assets/Prefabs/Managers/UniversalManagers/MainUniversalManagers/VfxManager.prefab
+++ b/Assets/Prefabs/Managers/UniversalManagers/MainUniversalManagers/VfxManager.prefab
@@ -81,17 +81,11 @@ MonoBehaviour:
     _poolingAmount: 5
     _vfxDurationType: 2
     _fixedDuration: 0
-  - _vfxName: Smoke Plume
+  - _vfxName: Healing Vfx
     _vfxObject: {fileID: 8544335786728863607, guid: 29c59d25c074ab144be794768677f2fc,
       type: 3}
-    _poolingAmount: 5
-    _vfxDurationType: 2
-    _fixedDuration: 0
-  - _vfxName: Smoke Plume
-    _vfxObject: {fileID: 8544335786728863607, guid: 29c59d25c074ab144be794768677f2fc,
-      type: 3}
-    _poolingAmount: 5
-    _vfxDurationType: 2
+    _poolingAmount: 3
+    _vfxDurationType: 0
     _fixedDuration: 0
   _visualAudioEffectBank:
   - AssociatedMaterial: {fileID: 2100000, guid: a5c634905b53a794fa487b8e4287d5dc,

--- a/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/VfxManager.cs
+++ b/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/VfxManager.cs
@@ -41,6 +41,7 @@ public class VfxManager : MainUniversalManagerFramework
     private const int _WOODEN_SPARKS_ID = 3;
     private const int _METAL_SPARKS_ID = 4;
     private const int _PLUME_SMOKE_ID = 5;
+    private const int _HEALING_EFFECT_ID = 6;
 
     /// <summary>
     /// Triggers the Light Shift Horror Moment
@@ -170,6 +171,7 @@ public class VfxManager : MainUniversalManagerFramework
     public SpecificVisualEffect GetMetalSparksVfx() => _allVfxInGame[_METAL_SPARKS_ID];
     public SpecificVisualEffect GetWoodenSparksVfx() => _allVfxInGame[_WOODEN_SPARKS_ID];
     public SpecificVisualEffect GetPlumeSmokeVfx() => _allVfxInGame[_PLUME_SMOKE_ID];
+    public SpecificVisualEffect GetHealingVfx() => _allVfxInGame[_HEALING_EFFECT_ID];
 
     public HarpoonVisualAudioEffectsBank[] GetHarpoonVisualArray() => _visualAudioEffectBank;
     #endregion

--- a/Assets/Scripts/WorldScripts/Interactables/HealthPackInteractable.cs
+++ b/Assets/Scripts/WorldScripts/Interactables/HealthPackInteractable.cs
@@ -56,6 +56,7 @@ public class HealthPackInteractable : TogglableInteractable, IPlayerInteractable
         }
 
         PlayerManager.Instance.OnInvokePlayerHealEvent(_healthRestored);
+        PlayHealingVisualEffect();
         _numUses--;
 
         if (_numUses == 0)
@@ -73,5 +74,14 @@ public class HealthPackInteractable : TogglableInteractable, IPlayerInteractable
     {
         _canInteract = percentHealth < 1;
         UpdateInteractablePopupToggle();
+    }
+
+    /// <summary>
+    /// Plays the healing visual effect
+    /// </summary>
+    private void PlayHealingVisualEffect()
+    {
+        VfxManager.Instance.GetHealingVfx().PlayNextVfxInPool
+            (transform.position, transform.rotation);
     }
 }


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?assignee=6318bb796856bdd60aa045de&selectedIssue=LV-1595

Healing from a health pack can now play vfx on the health pack. Its currently just using the steam vfx, which obviously does not make any sense in the context of healing, but this is the engineering side. Currently an issue relating to saving is making things act wonky. It might be easier to test this after that PR has already gone through and this has been updated off of that.

How to test: Use a health pack when hurt

Code Review Estimation: <2 minutes
In Engine Review Estimation: <5 minutes