### PR TITLE
gold-eng-SFX-Trigger-for-Main-Menu-Moving-Down-LV-1718

### DIFF
--- a/Assets/General/Audio/FMODScripts/FmodSfxEvents.cs
+++ b/Assets/General/Audio/FMODScripts/FmodSfxEvents.cs
@@ -26,6 +26,9 @@ public class FmodSfxEvents : MonoBehaviour
     [field: SerializeField] public EventReference VoiceVolumeSettingsChanged { get; private set; }
     [field: SerializeField] public EventReference MusicVolumeSettingsChanged { get; private set; }
 
+    [field:Space]
+    [field: SerializeField] public EventReference TitleScreenSplash { get; private set; }
+
     #endregion
 
     #region Boss

--- a/Assets/Scenes/BuildScenes/TitleScreen.unity
+++ b/Assets/Scenes/BuildScenes/TitleScreen.unity
@@ -1366,6 +1366,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _movingDestination: {fileID: 324132671}
   _screenScrollSpeed: 30
+  _splashEffectDelay: 0.5
   _sceneCanvas: {fileID: 1668942281}
   _enterFadeOutAnimator: {fileID: 901565831}
   _setUpPlayerControls: {fileID: 887760780}

--- a/Assets/Scripts/MenuFunctionality/TitleScreenScrolling.cs
+++ b/Assets/Scripts/MenuFunctionality/TitleScreenScrolling.cs
@@ -20,6 +20,8 @@ public class TitleScreenScrolling : MonoBehaviour
 
     [Tooltip("how fast the screen scrolls when it is started")]
     [SerializeField] private float _screenScrollSpeed;
+    [Tooltip("The delay before the splash effect plays")]
+    [SerializeField] private float _splashEffectDelay;
 
     [SerializeField] private Canvas _sceneCanvas;
 
@@ -54,6 +56,7 @@ public class TitleScreenScrolling : MonoBehaviour
 
         if (!_hasScrollingStarted)
         {
+            PrimeTween.Tween.Delay(this, _splashEffectDelay, PlayMainMenuSplash);
             _hasScrollingStarted = true;
             while (transform.position != destination)
             {
@@ -73,6 +76,14 @@ public class TitleScreenScrolling : MonoBehaviour
                 yield return null;
             }
         }
+    }
+
+    /// <summary>
+    /// Plays the sound effect of the main menu splash effect
+    /// </summary>
+    private void PlayMainMenuSplash()
+    {
+        RuntimeSfxManager.APlayOneShotSfx(FmodSfxEvents.Instance.TitleScreenSplash, Vector3.zero);
     }
 
     private void OnEnable()


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?assignee=6318bb796856bdd60aa045de&selectedIssue=LV-1718

Pretty simple. There is functionality to play a sound effect on the main menu when it goes underwater. 
Currently there is no sound effect in the slot, but for testing feel free to temporarily add one

Code Review Estimation: <3 minutes
In Engine Review Estimation: <4 minutes