### PR TITLE
gold-eng-Mouse-Note-Bug-LV-1625

### DIFF
--- a/Assets/Prefabs/PlayerPrefabs/PlayerKit.prefab
+++ b/Assets/Prefabs/PlayerPrefabs/PlayerKit.prefab
@@ -383,6 +383,8 @@ MonoBehaviour:
   _jumpscareTime: 0.1
   _jumpscareIntensity: 5
   _harpoonFollowTime: 5
+  _timeToReturnToMaxSpeed: 0.3
+  _delayToReturnToMaxSpeed: 0.1
 --- !u!114 &7573169614060137600
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -531,7 +533,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5131231787490673698}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0.08795113, y: -0.32423258, z: -0.03029195, w: 0.9413927}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -742,7 +744,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_RecenterTarget: 0
   m_VerticalAxis:
-    Value: 0
+    Value: -10.674914
     m_SpeedMode: 0
     m_MaxSpeed: 450
     m_AccelTime: 1
@@ -766,7 +768,7 @@ MonoBehaviour:
     m_LegacyHeadingDefinition: -1
     m_LegacyVelocityFilterStrength: -1
   m_HorizontalAxis:
-    Value: 0
+    Value: -38.009254
     m_SpeedMode: 0
     m_MaxSpeed: 450
     m_AccelTime: 1

--- a/Assets/Scripts/PlayerScripts/PlayerCameraController.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerCameraController.cs
@@ -444,18 +444,14 @@ public class PlayerCameraController : MonoBehaviour
     {
         //ResetToStoredSensitivity();
         float returnSpeedProgress = 0;
-        print("A");
         yield return _delayToMaxSpeedWait;
-        print("B");
         while (returnSpeedProgress < 1)
         {
-            print(returnSpeedProgress);
             returnSpeedProgress+= Time.deltaTime/_timeToReturnToMaxSpeed;
             SetCinemachineSpeed(Mathf.Lerp(0, _storedSensitivity.x, returnSpeedProgress),
                 Mathf.Lerp(0, _storedSensitivity.y, returnSpeedProgress));
             yield return null;
         }
-        print("Done");
     }
 
     /// <summary>

--- a/Assets/Scripts/PlayerScripts/PlayerCameraController.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerCameraController.cs
@@ -36,6 +36,7 @@ public class PlayerCameraController : MonoBehaviour
     // Variables for the Virtual Camera
     private CinemachineVirtualCamera _virtualCamera;
     private CinemachineTransposer _transposer;
+    private CinemachinePOV _cinemachinePOV;
 
     // Variables that relate to the camera's coroutines
     private Coroutine _cameraCoroutine;
@@ -77,6 +78,12 @@ public class PlayerCameraController : MonoBehaviour
     private float _harpoonHorizontalVelocity;
     private float _harpoonVerticalVelocity;
 
+    [Space]
+    [SerializeField] private float _timeToReturnToMaxSpeed;
+    [SerializeField] private float _delayToReturnToMaxSpeed;
+    private WaitForSeconds _delayToMaxSpeedWait;
+    private Coroutine _cameraSpeedReturnCoroutine;
+
     // Cached variables
     private WaitForFixedUpdate _fixedUpdate = new WaitForFixedUpdate();
     private Transform _playerTransform;
@@ -84,6 +91,10 @@ public class PlayerCameraController : MonoBehaviour
     private Transform _harpoonTransform;
 
     private bool _isReticleFullyZoomed;
+
+    private Vector2 _storedSensitivity;
+
+    private CinemachineBrain _cinemachineBrain;
 
     /// <summary>
     /// Whether the reticle is visually fully shrunken or not.
@@ -94,11 +105,9 @@ public class PlayerCameraController : MonoBehaviour
     }
 
     /// <summary>
-    /// This function is called before the first frame update.
-    /// Used to initialize any variables that are not serialized
-    /// and to start the coroutine
+    /// Performs any needed set up before the first frame
     /// </summary>
-    void Start()
+    public void CameraSetup()
     {
         EstablishInstance();
 
@@ -133,9 +142,30 @@ public class PlayerCameraController : MonoBehaviour
     {
         _virtualCamera = GetComponent<CinemachineVirtualCamera>();
         _transposer = _virtualCamera.GetCinemachineComponent<CinemachineTransposer>();
+        _cinemachinePOV = _virtualCamera.GetCinemachineComponent<CinemachinePOV>();
 
         _harpoonAnimator = _harpoonGun.GetComponent<Animator>();
         _cameraTransform = Camera.main.transform;
+
+        _delayToMaxSpeedWait = new WaitForSeconds(_delayToReturnToMaxSpeed);
+        InitializeStoredSensitivity();
+    }
+
+    /// <summary>
+    /// Sets the stored sensitivity to its default values
+    /// </summary>
+    private void InitializeStoredSensitivity()
+    {
+        _storedSensitivity = new Vector2(_cinemachinePOV.m_HorizontalAxis.m_MaxSpeed,
+            _cinemachinePOV.m_VerticalAxis.m_MaxSpeed);
+    }
+
+    /// <summary>
+    /// Resets the value of the sensitivity to its stored value
+    /// </summary>
+    private void ResetToStoredSensitivity()
+    {
+        SetCinemachineSpeed(_storedSensitivity.x, _storedSensitivity.y);
     }
 
     /// <summary>
@@ -389,6 +419,7 @@ public class PlayerCameraController : MonoBehaviour
         {
             _cameraCoroutine = StartCoroutine(MoveCamera());
             UnityEngine.Cursor.lockState = CursorLockMode.Locked;
+            _cameraSpeedReturnCoroutine = StartCoroutine(ReturnCameraSpeed());
         }
         else
         {
@@ -396,8 +427,46 @@ public class PlayerCameraController : MonoBehaviour
             {
                 StopCoroutine(_cameraCoroutine);
             }
+            if(_cameraSpeedReturnCoroutine != null)
+            {
+                StopCoroutine(_cameraSpeedReturnCoroutine);
+            }
             UnityEngine.Cursor.lockState = CursorLockMode.None;
+            SetCinemachineSpeed(0, 0);
         }
+    }
+
+    /// <summary>
+    /// Returns the camera to its default speed
+    /// </summary>
+    /// <returns></returns>
+    private IEnumerator ReturnCameraSpeed()
+    {
+        //ResetToStoredSensitivity();
+        float returnSpeedProgress = 0;
+        print("A");
+        yield return _delayToMaxSpeedWait;
+        print("B");
+        while (returnSpeedProgress < 1)
+        {
+            print(returnSpeedProgress);
+            returnSpeedProgress+= Time.deltaTime/_timeToReturnToMaxSpeed;
+            SetCinemachineSpeed(Mathf.Lerp(0, _storedSensitivity.x, returnSpeedProgress),
+                Mathf.Lerp(0, _storedSensitivity.y, returnSpeedProgress));
+            yield return null;
+        }
+        print("Done");
+    }
+
+    /// <summary>
+    /// Sets the speed of the cinemachine camera
+    /// </summary>
+    /// <param name="x"></param>
+    /// <param name="y"></param>
+    private void SetCinemachineSpeed(float x, float y)
+    {
+        _cinemachinePOV.m_HorizontalAxis.m_MaxSpeed =x;
+        _cinemachinePOV.m_VerticalAxis.m_MaxSpeed =y;
     }
 
     /// <summary>

--- a/Assets/Scripts/PlayerScripts/PlayerFunctionalityCore.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerFunctionalityCore.cs
@@ -50,6 +50,7 @@ public class PlayerFunctionalityCore : MonoBehaviour
         Instance = this;
         // Sets needed variables in the player movement controller before movement begins
         _playerMovementController.SetUpMovementController();
+        PlayerCamera.CameraSetup();
     }
 
     private void OnEnable()


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?assignee=712020%3A95314f55-18f3-4eed-888f-97f6fd939390&selectedIssue=LV-1625

Definitely ignore the fact Jira says this is a Charlie task. I am definitely Charlie, no doubt about it. Nothing suspicious. Anyway the issue on Jira is a bit vague so what this is fixing is that weird shake that happens when leaving a note if you are moving your mouse at the same time. I tried a bunch of different stuff to try to prevent it from happening, but I think it just comes down to the fact that cinemachine still reads the mouse inputs even when the camera isn't following. Best workaround I could find was to make the mouse be unable to be moved the moment the resume happens, and have it return to the base speed swiftly. If someone knows if the original issue is solvable let me know, I searched around for a while.
Bonus: This also fixes it for when you are unpause the game or close the tutorial
How to test: Move your mouse around while closing a note (or pause screen, or tutorial)

Code Review Estimation: <5 minutes
In Engine Review Estimation: <4 minutes