### PR TITLE
gold-eng-Resume-time-when-going-to-title-screen-LV-1979

### DIFF
--- a/Assets/Prefabs/PauseMenuCanvas.prefab
+++ b/Assets/Prefabs/PauseMenuCanvas.prefab
@@ -1310,6 +1310,18 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
+      - m_Target: {fileID: 9055069616428078226}
+        m_TargetAssemblyTypeName: PauseMenu, Assembly-CSharp
+        m_MethodName: PauseToggle
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
       - m_Target: {fileID: 6055096224721929835}
         m_TargetAssemblyTypeName: SceneLoadingButtons, Assembly-CSharp
         m_MethodName: ReloadTitleScreenButton


### PR DESCRIPTION
Fixed pause menu freezing time

Death screen should not be affected/cause any problems

This should take about 10 minutes to test, because you have to make a build and go from the pause screen to the title screen

You can also try to die and go to title screen for an extra lil test, probably 5 more minutes

[Jira Link](https://bradleycapstone.atlassian.net/browse/LV-1979)