### PR TITLE
bug-window-asset-should-have-a-dark-skybox-like-the-title-screen-LV-1980

### DIFF
--- a/Assets/Art/3D/Windows/Materials/FakeFog.mat
+++ b/Assets/Art/3D/Windows/Materials/FakeFog.mat
@@ -115,8 +115,8 @@ Material:
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
-    - _BaseColor: {r: 0.449, g: 0.43360063, b: 0.41723114, a: 1}
-    - _Color: {r: 0.44899994, g: 0.4336006, b: 0.4172311, a: 1}
+    - _BaseColor: {r: 0.07100392, g: 0.07645771, b: 0.08627451, a: 1}
+    - _Color: {r: 0.07100391, g: 0.0764577, b: 0.08627448, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Art/3D/Windows/Materials/LightShaft.mat
+++ b/Assets/Art/3D/Windows/Materials/LightShaft.mat
@@ -118,8 +118,8 @@ Material:
     - _WorkflowMode: 1
     - _ZWrite: 0
     m_Colors:
-    - _BaseColor: {r: 1, g: 0.8737889, b: 0.53301877, a: 0.039215688}
-    - _Color: {r: 1, g: 0.8737889, b: 0.53301877, a: 0.039215688}
+    - _BaseColor: {r: 0.823, g: 0.80034876, b: 0.613958, a: 0.03137255}
+    - _Color: {r: 0.823, g: 0.80034876, b: 0.613958, a: 0.03137255}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Prefabs/PlayerPrefabs/PlayerKit.prefab
+++ b/Assets/Prefabs/PlayerPrefabs/PlayerKit.prefab
@@ -753,7 +753,7 @@ MonoBehaviour:
   _fakeWindowCaptureContainer: {fileID: 1695045253923563657, guid: 419aa0c2783469d4ea30b2df2568fd29,
     type: 3}
   _worldSpawnPos: {x: 0, y: 0, z: 1500}
-  _maxFollowDistance: 15
+  _maxFollowDistance: 10
 --- !u!1 &8563142598887208412
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/PlayerPrefabs/PlayerKit.prefab
+++ b/Assets/Prefabs/PlayerPrefabs/PlayerKit.prefab
@@ -752,8 +752,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _fakeWindowCaptureContainer: {fileID: 1695045253923563657, guid: 419aa0c2783469d4ea30b2df2568fd29,
     type: 3}
-  _worldSpawnPos: {x: 0, y: 0, z: 1500}
-  _maxFollowDistance: 10
+  _worldSpawnPos: {x: 1500, y: 1500, z: 1500}
+  _maxFollowDistance: 5
 --- !u!1 &8563142598887208412
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/WorldPrefabs/Window/FakeWindowContainer.prefab
+++ b/Assets/Prefabs/WorldPrefabs/Window/FakeWindowContainer.prefab
@@ -383,13 +383,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1972615849947663872}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalRotation: {x: -0.1718556, y: -0.82799, z: 0.38609877, w: -0.36854565}
   m_LocalPosition: {x: 41.572033, y: -1.3714619, z: -230.5268}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5841644428710788670}
-  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -227.989, z: 0}
 --- !u!108 &6613653894376321498
 Light:
   m_ObjectHideFlags: 0
@@ -402,7 +402,7 @@ Light:
   m_Type: 1
   m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
-  m_Intensity: 0.24
+  m_Intensity: 0.5
   m_Range: 10
   m_SpotAngle: 30
   m_InnerSpotAngle: 21.80208

--- a/Assets/Prefabs/WorldPrefabs/Window/FakeWindowContainer.prefab
+++ b/Assets/Prefabs/WorldPrefabs/Window/FakeWindowContainer.prefab
@@ -402,7 +402,7 @@ Light:
   m_Type: 1
   m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
-  m_Intensity: 1.76
+  m_Intensity: 0.24
   m_Range: 10
   m_SpotAngle: 30
   m_InnerSpotAngle: 21.80208
@@ -445,7 +445,7 @@ Light:
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
-  m_ColorTemperature: 6104
+  m_ColorTemperature: 7588
   m_UseColorTemperature: 1
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0

--- a/Assets/Scripts/Maze/FakeWindowManager.cs
+++ b/Assets/Scripts/Maze/FakeWindowManager.cs
@@ -33,11 +33,11 @@ public class FakeWindowManager : MonoBehaviour
     [SerializeField] private Vector3 _worldSpawnPos = new(0.0F, 0.0F, 1500.0F);
 
     [SerializeField] private float _maxFollowDistance = 10.0F;
-    
+
     /// <summary>
-    /// Reference to every fake window in the scene
+    /// Reference to the current fake window
     /// </summary>
-    private List<FakeWindowObject> _fakeWindows;
+    private FakeWindowObject _fakeWindow;
 
     /// <summary>
     /// The camera responsible for rendering the fake windows
@@ -47,7 +47,7 @@ public class FakeWindowManager : MonoBehaviour
     /// <summary>
     /// _captureContainerCamera's initial position in WS
     /// </summary>
-    private Vector3 _initialCameraPosition; 
+    private Vector3 _initialCameraPosition;
     
     /// <summary>
     /// Register global singleton, spawn capture container if it does not exist already
@@ -63,9 +63,6 @@ public class FakeWindowManager : MonoBehaviour
         { 
             Instance = this; 
         }
-
-        // Allocate fake window list
-        _fakeWindows = new();
 
         // Spawn capture container in scene
         var container = Instantiate(
@@ -90,21 +87,13 @@ public class FakeWindowManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Add a fake window object to the global registry
+    /// Sets the current fake window
     /// </summary>
     /// <param name="fakeWindow">The fake window reference</param>
-    public void RegisterFakeWindow(FakeWindowObject fakeWindow)
+    public void SetCurrentFakeWindow(FakeWindowObject fakeWindow)
     {
-        _fakeWindows.Add(fakeWindow);
-    }
-
-    /// <summary>
-    /// Remove a fake window object to the global registry
-    /// </summary>
-    /// <param name="fakeWindow">The fake window reference</param>
-    public void UnregisterFakeWindow(FakeWindowObject fakeWindow)
-    {
-        _fakeWindows.Remove(fakeWindow);
+        _fakeWindow = fakeWindow;
+        _captureContainerCamera.transform.position = _initialCameraPosition;
     }
 
     /// <summary>
@@ -114,44 +103,23 @@ public class FakeWindowManager : MonoBehaviour
     /// </summary>
     void Update()
     {
-        // Find the closest window (going with a naive brute-force
-        // search because checking distance is pretty quick and
-        // there will probably not be any more than 2 or 3 windows
-        // in a given scene)
-        FakeWindowObject closestWindow = null;
-        Vector3 cameraPos = transform.position;
-
-        float dist = 0.0F;
-        float minDistance = float.MaxValue;
-
-        foreach (var window in _fakeWindows)
-        {
-            // Discard null entries
-            if (window.IsUnityNull())
-            {
-                continue;
-            }
-            
-            dist = Vector3.Distance(cameraPos, window.transform.position);
-
-            if (dist < minDistance)
-            {
-                minDistance = dist;
-                closestWindow = window;
-            }
-        }
-
-        // If there is no result, no need to run anything else
-        if (closestWindow.IsUnityNull())
+        // Do nothing if fake window is not set
+        if (_fakeWindow.IsUnityNull())
         {
             return;
         }
-
+        
+        // Get global camera position
+        var cameraPos = transform.position;
+        
         // Get rotation based on the vector between the closest
         // window and the current camera position
         var newRotation = Quaternion.LookRotation(
-            closestWindow.transform.position - cameraPos
+            _fakeWindow.transform.position - cameraPos
         ).eulerAngles;
+
+        // Account for level/window rotation
+        newRotation.y -= _fakeWindow.transform.eulerAngles.y - 90.0F;
         
         // Prevent any weird gimbal stuff when converting from
         // quaternion -> euler rotation
@@ -162,7 +130,7 @@ public class FakeWindowManager : MonoBehaviour
             newRotation;
         
         // Get offset to be applied to the capture camera
-        var offset = closestWindow.transform.position - cameraPos;
+        var offset = _fakeWindow.transform.position - cameraPos;
 
         // Clamp follow distance
         offset.x = Mathf.Clamp(offset.x, -_maxFollowDistance, _maxFollowDistance);

--- a/Assets/Scripts/Maze/FakeWindowObject.cs
+++ b/Assets/Scripts/Maze/FakeWindowObject.cs
@@ -26,20 +26,10 @@ public class FakeWindowObject : MonoBehaviour
     /// Ensure existence of FakeWindowManager, which spawns
     /// the capture container
     /// </summary>
-    private void Start()
+    private void OnEnable()
     {
         _fakeWindowManager = FakeWindowManager.Instance;
         Debug.Assert(!_fakeWindowManager.IsUnityNull());
-        
-        _fakeWindowManager.RegisterFakeWindow(this);
-    }
-
-    /// <summary>
-    /// When destroyed, remove this window from the global
-    /// registry
-    /// </summary>
-    private void OnDestroy()
-    {
-        _fakeWindowManager.UnregisterFakeWindow(this);
+        _fakeWindowManager.SetCurrentFakeWindow(this);
     }
 }


### PR DESCRIPTION
Made window background darker to fit with the intro cutscene, fixed "black box" issue with the camera bounds

A few minor code changes:
- Got rid of the global registry/distance check in FakeWindowManager.cs since it just overcomplicated things
- Added an extra term in the view angle calculation to account for which direction the window is facing in world space (aka fixing the black box issue)
- Edited FakeWindowObject.cs to work with the changes in FakeWindowManager.cs