### PR TITLE
gold-art-fix-water-shader-lv-1763

### DIFF
--- a/Assets/Art/TechArt/WorldShaders/Water/WaterInterior.mat
+++ b/Assets/Art/TechArt/WorldShaders/Water/WaterInterior.mat
@@ -142,13 +142,13 @@ Material:
     - _Metallic: 0
     - _NormalIntensity: 1
     - _OcclusionStrength: 1
-    - _OverallHeightAdjust: 0.05
+    - _OverallHeightAdjust: 0.2
     - _Parallax: 0.005
     - _PerlinNoiseTiling: 1.45
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
-    - _RefractionIntensity: 0.126
+    - _RefractionIntensity: 0.075
     - _RippleIntensity: 2
     - _RippleSpeed: 1
     - _RippleTiling: 8
@@ -180,12 +180,12 @@ Material:
     - _FoamColor: {r: 1, g: 1, b: 1, a: 0.12941177}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
     - _TopBottomGradientColor: {r: 0, g: 0, b: 0, a: 1}
-    - _WaterColor: {r: 0.32929868, g: 0.3773585, b: 0.35887396, a: 1}
+    - _WaterColor: {r: 0.583625, g: 0.667, b: 0.6392083, a: 1}
     - _WaterFogColor: {r: 0.16981131, g: 0.15602024, b: 0.090512626, a: 1}
-    - _WaterTint: {r: 0.16286932, g: 0.18867922, b: 0.16990839, a: 1}
+    - _WaterTint: {r: 0.5215, g: 0.59599996, b: 0.53391665, a: 1}
     - _WaveA: {r: 0.75, g: 0.5, b: 0.25, a: 2.34375}
-    - _WaveB: {r: -0.64, g: -0.7, b: 0.15, a: 1.09375}
-    - _WaveC: {r: 0.1, g: 0.31, b: 0.15, a: 0.8875}
+    - _WaveB: {r: -0.64, g: -0.7, b: 0.15, a: 1.27}
+    - _WaveC: {r: 0.1, g: 0.31, b: 0.15, a: 0.95}
     - _WaveD: {r: 0.07, g: 0.75, b: 0.15, a: 44}
     - _WaveE: {r: 0.8, g: 1, b: 0.07, a: 10}
   m_BuildTextureStacks: []


### PR DESCRIPTION
Made some edits to the water material used in maze 2 to fix any visual glitches and make it look more like water than a translucent plane