### PR TITLE
gold-eng-Medkit-doesn't-work-LV-2024

### DIFF
--- a/Assets/Scripts/PlayerScripts/PlayerFunctionalityCore.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerFunctionalityCore.cs
@@ -50,6 +50,7 @@ public class PlayerFunctionalityCore : MonoBehaviour
         Instance = this;
         // Sets needed variables in the player movement controller before movement begins
         _playerMovementController.SetUpMovementController();
+        _playerHealthController.SetUpHealth();
         PlayerCamera.CameraSetup();
     }
 

--- a/Assets/Scripts/PlayerScripts/PlayerHealth.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerHealth.cs
@@ -34,12 +34,37 @@ public class PlayerHealth : BaseHealth
     [SerializeField] private float _healthToEndHeartSfx;
     [SerializeField] private float _heartBeatRateSfx;
     private Coroutine _heartBeatCoroutine;
+
+    public static PlayerHealth Instance { get; private set; }
     
     protected override void Awake()
     {
         base.Awake();
         SubscribeToEvents();
         CanPlayerTakeDamage = true;
+    }
+
+    /// <summary>
+    /// Performs setup for the script
+    /// </summary>
+    public void SetUpHealth()
+    {
+        CheckSingletonInstance();
+    }
+
+    /// <summary>
+    /// Confirms whether this asset exists as a singleton.
+    /// </summary>
+    private void CheckSingletonInstance()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
     }
 
     private void OnDestroy()

--- a/Assets/Scripts/WorldScripts/Interactables/HealthPackInteractable.cs
+++ b/Assets/Scripts/WorldScripts/Interactables/HealthPackInteractable.cs
@@ -20,6 +20,16 @@ public class HealthPackInteractable : TogglableInteractable, IPlayerInteractable
     [SerializeField] private int _numUses = 3;
 
     /// <summary>
+    /// Performs needed set up on being enabled
+    /// </summary>
+    protected override void Start()
+    {
+        base.Start();
+        UpdateInteractability(PlayerHealth.Instance.GetHealthPercent(), 
+            PlayerHealth.Instance.GetCurrentHealth());
+    }
+
+    /// <summary>
     /// returns the number of uses
     /// </summary>
     /// <returns></returns>


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?assignee=6318bb796856bdd60aa045de&selectedIssue=LV-2024

Med kit works properly now. Problem was that the med kit only updated if it could be used when the player took damage. If you have a medkit in a different maze segment it would be disabled when you got hit, then when you enter that segment since the medkit starts unable to be used it wouldn't update. Now when a medkit is enabled it checks what it's interaction status should be.

How to test: Easiest way is to get to maze 3 and use the medkit on the wall. (You gotta be damaged at least once first)

Code Review Estimation: <3 minutes
In Engine Review Estimation: <6 minutes