### PR TITLE
gold-eng-Harpoon-gun-displacement-LV-1998

### DIFF
--- a/Assets/Art/Videos/DemoContextEdited.mp4.meta
+++ b/Assets/Art/Videos/DemoContextEdited.mp4.meta
@@ -1,0 +1,18 @@
+fileFormatVersion: 2
+guid: a61251786278478438a6249f66cd742b
+VideoClipImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  frameRange: 0
+  startFrame: -1
+  endFrame: -1
+  colorSpace: 0
+  deinterlace: 0
+  encodeAlpha: 0
+  flipVertical: 0
+  flipHorizontal: 0
+  importAudio: 1
+  targetSettings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/SaveData/Data.json
+++ b/Assets/Resources/SaveData/Data.json
@@ -1,3 +1,1 @@
-
-{"CurrentCheckpoint":0,"PlayerInventory":[],"CurrentStoryBeat":7,"CurrentSceneIndex":1,"CurrentMasterVolume":0.5,"CurrentSfxVolume":0.5,"CurrentAmbienceVolume":0.5,"CurrentVoiceVolume":0.5,"CurrentMusicVolume":0.5,"CurrentBrightness":0.5,"IsSubtitlesOn":true,"IsGoreOn":true,"IsUsingController":true}
-
+{"CurrentCheckpoint":0,"PlayerInventory":[],"CurrentStoryBeat":1,"CurrentSceneIndex":1,"CurrentMasterVolume":0.5,"CurrentSfxVolume":0.5,"CurrentAmbienceVolume":0.5,"CurrentVoiceVolume":0.5,"CurrentMusicVolume":0.5,"CurrentBrightness":0.5,"IsSubtitlesOn":true,"IsGoreOn":true,"IsUsingController":true}

--- a/Assets/Scripts/PlayerScripts/PlayerCameraController.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerCameraController.cs
@@ -96,6 +96,8 @@ public class PlayerCameraController : MonoBehaviour
 
     private CinemachineBrain _cinemachineBrain;
 
+    private InputAction _playerMovement;
+
     /// <summary>
     /// Whether the reticle is visually fully shrunken or not.
     /// </summary>
@@ -272,6 +274,12 @@ public class PlayerCameraController : MonoBehaviour
     /// <param name="playerMovement"> The InputAction associated with the player's movement for tracking </param>
     private void StartWalkingSway(InputAction playerMovement)
     {
+        // Let's keep the movement input action here
+        if (_playerMovement.IsUnityNull())
+        {
+            _playerMovement = playerMovement;
+        }
+
         // Stop the camera returning coroutine
         if (_walkingSwayCoroutine != null && _walkingSwayStarted == true)
         {
@@ -283,7 +291,7 @@ public class PlayerCameraController : MonoBehaviour
         if (_walkingSwayStarted == false)
         {
             _walkingSwayStarted = true;
-            _walkingSwayCoroutine = StartCoroutine(WalkingSway(playerMovement));   
+            _walkingSwayCoroutine = StartCoroutine(WalkingSway());   
         }
     }
 
@@ -291,13 +299,13 @@ public class PlayerCameraController : MonoBehaviour
     /// Simulates walking sway, going left and right periodically
     /// </summary>
     /// <param name="playerMovement"> The InputAction associated with the player's movement for tracking </param>
-    private IEnumerator WalkingSway(InputAction playerMovement)
+    private IEnumerator WalkingSway()
     {
         Coroutine stopSwayCoroutine = null;
 
         while (true)
         {
-            Vector2 moveDir = playerMovement.ReadValue<Vector2>();
+            Vector2 moveDir = _playerMovement.ReadValue<Vector2>();
 
             // We only really want to do movement sway if we are moving directly forward and the harpoon is idle
             // If we don't do this, this could lead to visual bugs
@@ -308,6 +316,7 @@ public class PlayerCameraController : MonoBehaviour
                 if (stopSwayCoroutine != null)
                 {
                     StopCoroutine(stopSwayCoroutine);
+                    stopSwayCoroutine = null;
                 }
 
                 // We would like to get the angle at which that camera is facing
@@ -349,7 +358,7 @@ public class PlayerCameraController : MonoBehaviour
                     // NO DUPLICATING COROUTINES
                     if (stopSwayCoroutine == null)
                     {
-                        //stopSwayCoroutine = StartCoroutine(ReturnCameraFromWalking(playerMovement));
+                        stopSwayCoroutine = StartCoroutine(ReturnCameraFromWalking());
                     }
                 }
             }
@@ -370,13 +379,13 @@ public class PlayerCameraController : MonoBehaviour
         }
 
         // Return camera to original position
-        _walkingSwayCoroutine = StartCoroutine(ReturnCameraFromWalking(null));
+        _walkingSwayCoroutine = StartCoroutine(ReturnCameraFromWalking());
     }
 
     /// <summary>
     /// Returns the camera to its original position from the walking sway motion
     /// </summary>
-    private IEnumerator ReturnCameraFromWalking(InputAction playerMovement)
+    private IEnumerator ReturnCameraFromWalking()
     {
         if (_harpoonAnimator.GetCurrentAnimatorClipInfo(0)[0].clip.name == _IDLE_ANIMATION)
         {
@@ -396,6 +405,7 @@ public class PlayerCameraController : MonoBehaviour
 
         // I'm deciding that our main character is right footed
         _movementSwayRight = true;
+        _walkingSwayStarted = false;
 
         // Prevents camera sway from getting duplicated
         if (_walkingSwayCoroutine != null)
@@ -404,9 +414,9 @@ public class PlayerCameraController : MonoBehaviour
         }
 
         // But wait, if we're still in motion, then we want to restart the walking sway
-        if (playerMovement != null && playerMovement.ReadValue<Vector2>() != Vector2.zero)
+        if (_playerMovement != null && _playerMovement.ReadValue<Vector2>() != Vector2.zero)
         {
-            _walkingSwayCoroutine = StartCoroutine(WalkingSway(playerMovement));
+            _walkingSwayCoroutine = StartCoroutine(WalkingSway());
         }
     }
 
@@ -503,6 +513,7 @@ public class PlayerCameraController : MonoBehaviour
     {
         PlayerManager.Instance.GetOnMovementStartEvent().AddListener(StartWalkingSway);
         PlayerManager.Instance.GetOnMovementEndEvent().AddListener(StopWalkingSway);
+        PlayerManager.Instance.GetOnHarpoonFocusStartEvent().AddListener(StopWalkingSway);
         CameraManager.Instance.GetOnJumpscareEvent().AddListener(JumpscarePullback);
     }
 
@@ -514,6 +525,7 @@ public class PlayerCameraController : MonoBehaviour
     {
         PlayerManager.Instance.GetOnMovementStartEvent().RemoveListener(StartWalkingSway);
         PlayerManager.Instance.GetOnMovementEndEvent().RemoveListener(StopWalkingSway);
+        PlayerManager.Instance.GetOnHarpoonFocusStartEvent().RemoveListener(StopWalkingSway);
         CameraManager.Instance.GetOnJumpscareEvent().RemoveListener(JumpscarePullback);
     }
 


### PR DESCRIPTION
Yippee! I took the opportunity to fix some other bugs I noticed with the walking sway. Now it should work just fine. For this you just need to check a couple things:
- When you focus the harpoon gun, the gun stays on-center during the animation
- When you return from focusing (whether or not you shot), the walking sway starts again
- As you change movement direction without stopping, the walking sway only happens when you walk directly forward

Jira Task: https://bradleycapstone.atlassian.net/browse/LV-1998?atlOrigin=eyJpIjoiNDZjYTI0ZWNmMmFlNDM1OGJiYmI3MWU1Y2QwODlkYmYiLCJwIjoiaiJ9

Code Review Time: <3 minutes (there are some ghost changes that you can ignore)
In-Engine Review Time: <5 minutes