### PR TITLE
gold-des-Monster-Spawn-Updates-LV-2112

### DIFF
--- a/Assets/Prefabs/WorldPrefabs/Mazes/Beta/ActualMazes/BetaMaze.prefab
+++ b/Assets/Prefabs/WorldPrefabs/Mazes/Beta/ActualMazes/BetaMaze.prefab
@@ -134699,6 +134699,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3575066472085477899, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
+      propertyPath: _attackInterval
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3575066472085477899, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
       propertyPath: _whackAMolePoints.Array.size
       value: 4
       objectReference: {fileID: 0}
@@ -134729,8 +134734,28 @@ PrefabInstance:
       objectReference: {fileID: 4319536786291788985}
     - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
       propertyPath: m_LocalPosition.z
-      value: -9.24
+      value: -9.2
       objectReference: {fileID: 0}
     - target: {fileID: 4077664978516323373, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
@@ -134845,32 +134870,32 @@ PrefabInstance:
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.x
-      value: 1.3694711
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.y
-      value: 1.228175
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.z
-      value: 0.34230086
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.x
-      value: 0.025502289
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.y
-      value: -0.28578508
+      value: -0.25
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.z
-      value: 0.012462141
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6817676328870073964, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
@@ -141921,6 +141946,36 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1000655990855641422}
     m_Modifications:
+    - target: {fileID: 19935392578070201, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 19935392578070201, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 19935392578070201, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 19935392578070201, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 19935392578070201, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 462407023816628176, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: _attackInterval
+      value: 2.5
+      objectReference: {fileID: 0}
     - target: {fileID: 462407023816628176, guid: b529249cab6684243880c044f3eabb72,
         type: 3}
       propertyPath: _whackAMolePoints.Array.size
@@ -142005,6 +142060,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7000926514995932082, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7000926514995932082, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7000926514995932082, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7000926514995932082, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7000926514995932082, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_Center.y
+      value: -0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7000926514995932082, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8415630018106362499, guid: b529249cab6684243880c044f3eabb72,
         type: 3}
@@ -145758,6 +145843,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3575066472085477899, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
+      propertyPath: _attackInterval
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3575066472085477899, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
       propertyPath: _whackAMolePoints.Array.size
       value: 4
       objectReference: {fileID: 0}
@@ -145783,8 +145873,28 @@ PrefabInstance:
       objectReference: {fileID: 3654928962151981555}
     - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
       propertyPath: m_LocalPosition.z
-      value: -9.24
+      value: -9.2
       objectReference: {fileID: 0}
     - target: {fileID: 4077664978516323373, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
@@ -145874,32 +145984,32 @@ PrefabInstance:
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.x
-      value: 1.1480426
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.y
-      value: 1.228175
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.z
-      value: 0.34230086
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.x
-      value: 0.063281536
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.y
-      value: -0.28578508
+      value: -0.25
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.z
-      value: 0.012462126
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6817676328870073964, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
@@ -159526,6 +159636,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3575066472085477899, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
+      propertyPath: _attackInterval
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3575066472085477899, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
       propertyPath: _whackAMolePoints.Array.size
       value: 4
       objectReference: {fileID: 0}
@@ -159556,8 +159671,28 @@ PrefabInstance:
       objectReference: {fileID: 8299855403738803819}
     - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
       propertyPath: m_LocalPosition.z
-      value: -9.24
+      value: -9.2
       objectReference: {fileID: 0}
     - target: {fileID: 4077664978516323373, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
@@ -159647,32 +159782,32 @@ PrefabInstance:
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.x
-      value: 1.0797869
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.y
-      value: 1.228175
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.z
-      value: 0.34230086
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.x
-      value: -0.022040816
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.y
-      value: -0.28578508
+      value: -0.25
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.z
-      value: 0.012462126
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6817676328870073964, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
@@ -170328,6 +170463,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3575066472085477899, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
+      propertyPath: _attackInterval
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3575066472085477899, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
       propertyPath: _whackAMolePoints.Array.size
       value: 4
       objectReference: {fileID: 0}
@@ -170353,8 +170493,28 @@ PrefabInstance:
       objectReference: {fileID: 2343470688064030096}
     - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
       propertyPath: m_LocalPosition.z
-      value: -9.24
+      value: -9.2
       objectReference: {fileID: 0}
     - target: {fileID: 4077664978516323373, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
@@ -170444,32 +170604,32 @@ PrefabInstance:
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.x
-      value: 1.1178867
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.y
-      value: 1.228175
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.z
-      value: 0.34230086
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.x
-      value: 0.011597717
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.y
-      value: -0.28578508
+      value: -0.25
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.z
-      value: 0.012462126
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6817676328870073964, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
@@ -198755,6 +198915,36 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1000655990855641422}
     m_Modifications:
+    - target: {fileID: 19935392578070201, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 19935392578070201, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 19935392578070201, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 19935392578070201, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 19935392578070201, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 462407023816628176, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: _attackInterval
+      value: 2.5
+      objectReference: {fileID: 0}
     - target: {fileID: 462407023816628176, guid: b529249cab6684243880c044f3eabb72,
         type: 3}
       propertyPath: _whackAMolePoints.Array.size
@@ -198839,6 +199029,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7000926514995932082, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7000926514995932082, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7000926514995932082, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7000926514995932082, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7000926514995932082, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_Center.y
+      value: -0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7000926514995932082, guid: b529249cab6684243880c044f3eabb72,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8415630018106362499, guid: b529249cab6684243880c044f3eabb72,
         type: 3}
@@ -212958,6 +213178,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3575066472085477899, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
+      propertyPath: _attackInterval
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3575066472085477899, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
       propertyPath: _whackAMolePoints.Array.size
       value: 4
       objectReference: {fileID: 0}
@@ -212983,8 +213208,28 @@ PrefabInstance:
       objectReference: {fileID: 6743325917244194317}
     - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013041096337582946, guid: 207bbe8efc148674880a0ab09758e0fe,
+        type: 3}
       propertyPath: m_LocalPosition.z
-      value: -9.24
+      value: -9.2
       objectReference: {fileID: 0}
     - target: {fileID: 4077664978516323373, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
@@ -213074,32 +213319,32 @@ PrefabInstance:
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.x
-      value: 0.99221665
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.y
-      value: 1.228175
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Size.z
-      value: 0.34230086
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.x
-      value: 0.17232822
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.y
-      value: -0.28578508
+      value: -0.25
       objectReference: {fileID: 0}
     - target: {fileID: 6259921214527907433, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}
       propertyPath: m_Center.z
-      value: 0.012462141
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6817676328870073964, guid: 207bbe8efc148674880a0ab09758e0fe,
         type: 3}


### PR DESCRIPTION
- adjusted triggers and transform values on monster spawns
- adjusted monster spawn speed from 5.5 to 2.5 which makes a new monster spawn as soon as the old one goes back into the hole