### PR TITLE
Adjusted the harpoon racks to not clip into walls

### DIFF
--- a/Assets/Prefabs/WorldPrefabs/Mazes/Beta/ActualMazes/BetaMaze.prefab
+++ b/Assets/Prefabs/WorldPrefabs/Mazes/Beta/ActualMazes/BetaMaze.prefab
@@ -99325,7 +99325,7 @@ PrefabInstance:
     - target: {fileID: 117062266582576949, guid: 657010d068ffc8244bbf26d2243abaed,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 78.32
+      value: 78.485
       objectReference: {fileID: 0}
     - target: {fileID: 117062266582576949, guid: 657010d068ffc8244bbf26d2243abaed,
         type: 3}
@@ -99470,12 +99470,12 @@ PrefabInstance:
     - target: {fileID: 6698540301541099115, guid: 657010d068ffc8244bbf26d2243abaed,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 3.496
+      value: 3.4960022
       objectReference: {fileID: 0}
     - target: {fileID: 6698540301541099115, guid: 657010d068ffc8244bbf26d2243abaed,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.8803599
+      value: 0.8756626
       objectReference: {fileID: 0}
     - target: {fileID: 6698540301541099115, guid: 657010d068ffc8244bbf26d2243abaed,
         type: 3}
@@ -99485,7 +99485,7 @@ PrefabInstance:
     - target: {fileID: 6698540301541099115, guid: 657010d068ffc8244bbf26d2243abaed,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.4743063
+      value: 0.48292327
       objectReference: {fileID: 0}
     - target: {fileID: 6698540301541099115, guid: 657010d068ffc8244bbf26d2243abaed,
         type: 3}
@@ -99495,7 +99495,7 @@ PrefabInstance:
     - target: {fileID: 6698540301541099115, guid: 657010d068ffc8244bbf26d2243abaed,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 56.628
+      value: 57.753
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []


### PR DESCRIPTION
I adjusted the final left side harpoon rack to not be clipping into the one way wall at the end there, and also the rack that is on the slanted wall to have the rack itself fully on the wall.

Jira task: https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32?jql=assignee%20%3D%2063c32962c52a63dcda83f747&selectedIssue=LV-2010

You can check this by just playing and checking if its in the wall or not