### PR TITLE
gold-eng-Functionality-for-pause-sfx-LV-2022

### DIFF
--- a/Assets/Scripts/MenuFunctionality/PauseMenu.cs
+++ b/Assets/Scripts/MenuFunctionality/PauseMenu.cs
@@ -95,7 +95,7 @@ public class PauseMenu : MonoBehaviour
         if(shouldToggleAudio)
         {
             // Pauses or resumes all the audio based on whether or not the menu is visible
-            FMODUnity.RuntimeManager.StudioSystem.getBus("bus:/", out FMOD.Studio.Bus masterBus);
+            FMODUnity.RuntimeManager.StudioSystem.getBus("bus:/In-Game", out FMOD.Studio.Bus masterBus);
             masterBus.setPaused(isVisible);
         }
     }


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?assignee=6318bb796856bdd60aa045de&selectedIssue=LV-2022

Welcome to the world's shortest PR. In this I made it so that only certain audio gets paused when the game pauses. Currently the only Fmod sounds that are set to not pause are called UIClick and PauseMusic. You will see that when the game is paused everything else pauses as normal but you can still hear the click sounds

Code Review Estimation: <1 minute
In Engine Review Estimation: <4 minutes