### PR TITLE
gold-eng-Player-footsteps-continue-when-the-player-tabs-out-LV-1999

### DIFF
--- a/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/RuntimeSfxManager.cs
+++ b/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/RuntimeSfxManager.cs
@@ -331,6 +331,19 @@ public class RuntimeSfxManager : AudioManager
         }
     }
 
+    /// <summary>
+    /// Unity calls this method whenever the application gains or loses focus on the OS side
+    /// Used to stop footsteps when you lose focus
+    /// </summary>
+    /// <param name="focus"> True when the app is in focus, false otherwise </param>
+    private void OnApplicationFocus(bool focus)
+    {
+        if (!focus)
+        {
+            StopFootsteps();
+        }
+    }
+
     #endregion Footsteps
 
     #endregion

--- a/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/RuntimeSfxManager.cs
+++ b/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/RuntimeSfxManager.cs
@@ -335,10 +335,10 @@ public class RuntimeSfxManager : AudioManager
     /// Unity calls this method whenever the application gains or loses focus on the OS side
     /// Used to stop footsteps when you lose focus
     /// </summary>
-    /// <param name="focus"> True when the app is in focus, false otherwise </param>
-    private void OnApplicationFocus(bool focus)
+    /// <param name="isFocused"> True when the app is in focus, false otherwise </param>
+    private void OnApplicationFocus(bool isFocused)
     {
-        if (!focus)
+        if (!isFocused)
         {
             StopFootsteps();
         }


### PR DESCRIPTION
Yippee! So thankfully Unity has some stuff that keeps track of whether or not the game is in focus. I just added one of those things where we handle the footsteps.

Jira Task: https://bradleycapstone.atlassian.net/browse/LV-1999?atlOrigin=eyJpIjoiNmJjZWU5ZDA4MjFhNDE2N2I2MGVjZGZiOWQ2MjEwZTgiLCJwIjoiaiJ9

Code Review Time: <1 minute
In-Engine Review Time: <5 minutes (just make a build, tab in and out of it, and make sure the footsteps don't play while you're out)