### PR TITLE
Objective changing LV-2069

### DIFF
--- a/Assets/Art/UI/UIAnimations/Objective/ObjectiveHudAnimator.controller
+++ b/Assets/Art/UI/UIAnimations/Objective/ObjectiveHudAnimator.controller
@@ -25,6 +25,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &-7212691459071681770
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: AbortSlide
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -894741001840215475}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1107 &-6368953905105169305
 AnimatorStateMachine:
   serializedVersion: 6
@@ -60,7 +85,10 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions: []
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: AbortSlide
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -894741001840215475}
   m_Solo: 0
@@ -70,7 +98,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0.25
   m_TransitionOffset: 0
   m_ExitTime: 0.75
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -87,6 +115,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 6367168495725583144}
+  - {fileID: -7212691459071681770}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -150,6 +179,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
+  - m_Name: AbortSlide
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -163,6 +198,28 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
+--- !u!1101 &5858807476490646909
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -894741001840215475}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &6367168495725583144
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -200,6 +257,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -5574915461602002664}
+  - {fileID: 5858807476490646909}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Art/UI/UIAnimations/Objective/ObjectiveSlideIn.anim
+++ b/Assets/Art/UI/UIAnimations/Objective/ObjectiveSlideIn.anim
@@ -23,7 +23,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: -325
+        value: -380
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -131,7 +131,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: -325
+        value: -380
         inSlope: 0
         outSlope: 0
         tangentMode: 136

--- a/Assets/Scripts/UI/ObjectiveHudBehaviour.cs
+++ b/Assets/Scripts/UI/ObjectiveHudBehaviour.cs
@@ -23,7 +23,8 @@ public class ObjectiveHudBehaviour : MonoBehaviour
     [SerializeField] private Animator _objectiveHudAnimator;
     [SerializeField] private TextMeshProUGUI _objectiveHudText;
     [SerializeField] private TextMeshProUGUI _objectivePauseText;
-    
+    [SerializeField] private Image[] _objectiveSprites;
+
     // Cached variables
     private WaitForSeconds _animationWait;
 
@@ -33,6 +34,7 @@ public class ObjectiveHudBehaviour : MonoBehaviour
     private void Awake()
     {
         _animationWait = new WaitForSeconds(_objectiveLingerTime);
+        _objectiveSprites = GetComponentsInChildren<Image>();
     }
 
     /// <summary>
@@ -41,11 +43,27 @@ public class ObjectiveHudBehaviour : MonoBehaviour
     /// <param name="objectiveHudTextString">the text that goes on the ui</param>
     public void ActivateObjectiveHud(string objectiveHudTextString) 
     {
+        //reset to default state if the animation is already going
+        if (_objectiveHudAnimator.GetCurrentAnimatorStateInfo(0).IsName("ObjectiveSlideIn"))
+        {
+            _objectiveHudAnimator.SetTrigger("AbortSlide");
+            _objectiveHudAnimator.ResetTrigger("SlideOut");
+            StopCoroutine(WaitForAnimation());
+        }
+
+        foreach(Image h in _objectiveSprites)
+        {
+            h.enabled = false;
+        }
+        _objectiveHudText.enabled = false;
+
+        //update text
         _objectiveHudText.text = objectiveHudTextString;
         // Mirrors info in pause menu
         SetPauseMenuObjective(objectiveHudTextString);
-
+        //starts slide animation
         _objectiveHudAnimator.SetTrigger("SlideIn");
+
         StartCoroutine(WaitForAnimation());
     }
 
@@ -72,6 +90,12 @@ public class ObjectiveHudBehaviour : MonoBehaviour
     /// <returns></returns>
     private IEnumerator WaitForAnimation()
     {
+        yield return new WaitForSeconds(0.5f);
+        foreach (Image h in _objectiveSprites)
+        {
+            h.enabled = true;
+        }
+        _objectiveHudText.enabled = true;
         yield return _animationWait;
         DeactivateObjectiveHud();
     }


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/browse/LV-2069

fixes an issue where triggering a new objective pop in while one is already in progress would display the new text for a brief moment before sliding in properly.

I tried a lot of more elegant solutions for this but none of them worked seemingly because the unity animator is just slow and bad (even with exit time checked off) so in the end I had to do a bit of a janky fix where I turn off the visual components of the objective hud for a short period while waiting for the animator to catch up. Far from ideal, but it's the only thing I could get to work.