### PR TITLE
LV-2143-Maze-Music-Not-Playing-Bug

### DIFF
--- a/Assets/Art/3D/Boss/BossPrefabs/WhackAMolePrefab.prefab
+++ b/Assets/Art/3D/Boss/BossPrefabs/WhackAMolePrefab.prefab
@@ -935,7 +935,7 @@ MonoBehaviour:
           m_BoolArgument: 1
         m_CallState: 2
   _exitType: 1
-  _musicExitID: 1
+  _musicExitID: 2
   _newExitVolume: 0
   _onPlayerExit:
     m_PersistentCalls:


### PR DESCRIPTION
Maze Music wasn't playing after monster encounter as it was being set to the wrong one. Fixed it

https://bradleycapstone.atlassian.net/browse/LV-2143

Just make sure that the music transitions from Boss to Maze properly