### PR TITLE
gold-qa-eng-unbreak-the-infinite-ammo-barrel

### DIFF
--- a/Assets/Prefabs/WorldPrefabs/Mazes/Beta/ActualMazes/BetaNormalZone.prefab
+++ b/Assets/Prefabs/WorldPrefabs/Mazes/Beta/ActualMazes/BetaNormalZone.prefab
@@ -13719,11 +13719,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7595225991383519971, guid: 47b220808d7c18f4b9396663e42a48f9,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Prefabs/WorldPrefabs/PlayerInteractables/InfiniteAmmoRack.prefab
+++ b/Assets/Prefabs/WorldPrefabs/PlayerInteractables/InfiniteAmmoRack.prefab
@@ -1624,7 +1624,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &6638341046493507509
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/BuildScenes/MazeSubScenes/AdditiveMaze01.unity
+++ b/Assets/Scenes/BuildScenes/MazeSubScenes/AdditiveMaze01.unity
@@ -470,7 +470,7 @@ PrefabInstance:
     - target: {fileID: 500180108547224157, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1295
+      value: 1298
       objectReference: {fileID: 0}
     - target: {fileID: 589789444823954167, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
@@ -485,7 +485,7 @@ PrefabInstance:
     - target: {fileID: 684008569623865887, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1307
+      value: 1310
       objectReference: {fileID: 0}
     - target: {fileID: 1170576594216396012, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
@@ -495,7 +495,7 @@ PrefabInstance:
     - target: {fileID: 1170576594216396012, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1295
+      value: 1298
       objectReference: {fileID: 0}
     - target: {fileID: 2544088819543245031, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
@@ -515,7 +515,7 @@ PrefabInstance:
     - target: {fileID: 3038786283677821564, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1593
+      value: 1596
       objectReference: {fileID: 0}
     - target: {fileID: 3240593814744337364, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
@@ -550,7 +550,7 @@ PrefabInstance:
     - target: {fileID: 4672357664736789104, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1295
+      value: 1298
       objectReference: {fileID: 0}
     - target: {fileID: 4780920110104550515, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
@@ -670,7 +670,7 @@ PrefabInstance:
     - target: {fileID: 7119928805048618662, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1593
+      value: 1596
       objectReference: {fileID: 0}
     - target: {fileID: 7293586619006186852, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
@@ -787,6 +787,11 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 1393734147}
+    - target: {fileID: 8295696497149629794, guid: af80e909c848a7546b5ce7c76365e151,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8340976393604504577, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: _objectSpriteReference

--- a/Assets/Scenes/BuildScenes/MazeSubScenes/AdditiveMaze03.unity
+++ b/Assets/Scenes/BuildScenes/MazeSubScenes/AdditiveMaze03.unity
@@ -1097,7 +1097,7 @@ PrefabInstance:
     - target: {fileID: 500180108547224157, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 599
+      value: 614
       objectReference: {fileID: 0}
     - target: {fileID: 589789444823954167, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
@@ -1122,7 +1122,7 @@ PrefabInstance:
     - target: {fileID: 684008569623865887, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 611
+      value: 626
       objectReference: {fileID: 0}
     - target: {fileID: 1170576594216396012, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
@@ -1132,7 +1132,7 @@ PrefabInstance:
     - target: {fileID: 1170576594216396012, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 599
+      value: 614
       objectReference: {fileID: 0}
     - target: {fileID: 1367436754805524366, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
@@ -1237,7 +1237,7 @@ PrefabInstance:
     - target: {fileID: 3038786283677821564, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 897
+      value: 912
       objectReference: {fileID: 0}
     - target: {fileID: 3181758711971035801, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
@@ -1332,7 +1332,7 @@ PrefabInstance:
     - target: {fileID: 4672357664736789104, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 599
+      value: 614
       objectReference: {fileID: 0}
     - target: {fileID: 4780920110104550515, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
@@ -1637,7 +1637,7 @@ PrefabInstance:
     - target: {fileID: 7119928805048618662, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 897
+      value: 912
       objectReference: {fileID: 0}
     - target: {fileID: 7144238122420335613, guid: af80e909c848a7546b5ce7c76365e151,
         type: 3}
@@ -1797,6 +1797,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 376571957}
+    - targetCorrespondingSourceObject: {fileID: 255226243737984219, guid: af80e909c848a7546b5ce7c76365e151,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: af80e909c848a7546b5ce7c76365e151, type: 3}
 --- !u!4 &376571955 stripped
 Transform:
@@ -3305,7 +3309,7 @@ PrefabInstance:
     - target: {fileID: 7507466144603418903, guid: 5431725e52cdb364994f427d60bf88ba,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1127
+      value: 1142
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []


### PR DESCRIPTION
Reenabled the interactable icon on the infinite ammo barrel. I am aware that the player cannot interact with the infinite ammo barrel in the first maze, that's the whole reason the interactable icons were disabled in the first place. Production decided that isn't getting fixed, they just wanted the issue with reloading fixed.