### PR TITLE
pg-eng-Resolution-choices-aren't-consistent-LV-2165

### DIFF
--- a/Assets/Scripts/UI/VideoSettingsBehaviour.cs
+++ b/Assets/Scripts/UI/VideoSettingsBehaviour.cs
@@ -58,7 +58,6 @@ public class VideoSettingsBehaviour : MonoBehaviour
         }
         
         AddResolutionsToDropdown();
-        SelectDefaultResolution();
 
         _resolutionDropdown.onValueChanged.AddListener(ChangeResolution);
         
@@ -197,7 +196,15 @@ public class VideoSettingsBehaviour : MonoBehaviour
     }
     
     #endregion
-    
+
+    /// <summary>
+    /// Prevents the top resolution from always being the first selected
+    /// </summary>
+    private void OnEnable()
+    {
+        SelectDefaultResolution();
+    }
+
     /// <summary>
     /// This removes the listener to check if the resolution has changed
     /// </summary>


### PR DESCRIPTION
[Jira Ticket](https://bradleycapstone.atlassian.net/browse/LV-2165?atlOrigin=eyJpIjoiYTI2NzhlY2YyMTFhNGZjMWI0NTNjMDEwNGRjN2ZmZDMiLCJwIjoiaiJ9)


Every time the player goes into the settings and video section, the resolution setting should have the correct resolution selected. Need to test in build.

Time Estimate: 10 minutes