### PR TITLE
pg-eng-Footsteps-not-playing-at-the-right-speed-LV-2160

### DIFF
--- a/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/RuntimeSfxManager.cs
+++ b/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/RuntimeSfxManager.cs
@@ -314,7 +314,8 @@ public class RuntimeSfxManager : AudioManager
     private IEnumerator LoopFootSteps()
     {
         // Update the initial footstep speed
-        float currentSpeedMultiplier = PlayerMovementController.Instance.CurrentFocusMoveSpeedMultiplier;
+        float currentSpeedMultiplier = PlayerMovementController.Instance.CurrentFocusMoveSpeedMultiplier * 
+            PlayerMovementController.Instance.CurrentReloadMoveSpeedMultiplier;
         firstFootstepDelay = new WaitForSeconds(FmodSfxEvents.Instance.FirstFootstepDelay
             * (1 + (1 - currentSpeedMultiplier)));
 
@@ -327,7 +328,8 @@ public class RuntimeSfxManager : AudioManager
             PlayFootStep();
 
             // Update the footstep speed
-            currentSpeedMultiplier = PlayerMovementController.Instance.CurrentFocusMoveSpeedMultiplier;
+            currentSpeedMultiplier = PlayerMovementController.Instance.CurrentFocusMoveSpeedMultiplier *
+                PlayerMovementController.Instance.CurrentReloadMoveSpeedMultiplier;
             footstepDelay = new WaitForSeconds(FmodSfxEvents.Instance.FootstepDelay
                 * (1 + (1 - currentSpeedMultiplier)));
 

--- a/Assets/Scripts/PlayerScripts/PlayerMovementController.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerMovementController.cs
@@ -718,6 +718,8 @@ public class PlayerMovementController : MonoBehaviour
     // Getter for the current movement ratio
     public float CurrentFocusMoveSpeedMultiplier => _currentFocusMoveSpeedMultiplier;
 
+    public float CurrentReloadMoveSpeedMultiplier => _currentReloadMoveSpeedMultiplier;
+
     public float PlayerMovementSpeed { get => _playerMovementSpeed; set => _playerMovementSpeed = value; }
 
     #endregion Getters


### PR DESCRIPTION
Footstep audio now scales with the reloading speed change. Yippee!

Jira Task: https://bradleycapstone.atlassian.net/browse/LV-2160?atlOrigin=eyJpIjoiNGJjM2IyYmZiODJlNDM5NGI4MWU5NGYzMmNjZTE5ZDgiLCJwIjoiaiJ9

In-Engine Review Time: <2 minutes (just shoot a few times and you should hear the timing change)
Code Review Time: <2 minutes