### PR TITLE
Pg des fix trashpile colliders

### DIFF
--- a/Assets/Prefabs/WorldPrefabs/Mazes/Beta/ActualMazes/BetaMaze.prefab
+++ b/Assets/Prefabs/WorldPrefabs/Mazes/Beta/ActualMazes/BetaMaze.prefab
@@ -38205,6 +38205,7 @@ Transform:
   m_Children:
   - {fileID: 2589538798388406921}
   - {fileID: 7575346756887057817}
+  - {fileID: 8570744633975142964}
   - {fileID: 7549537450165111755}
   - {fileID: 7182004398915392501}
   - {fileID: 4433815633140527492}
@@ -52004,6 +52005,40 @@ MonoBehaviour:
   _doesReturnColor: 1
   _lightTransitionTime: 1
   _lightShiftDuration: 20
+--- !u!1 &6885550815427751765
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4905704404817845342}
+  m_Layer: 0
+  m_Name: Harpoons in walls
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4905704404817845342
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6885550815427751765}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8246887349624833005}
+  - {fileID: 5420492177450255013}
+  - {fileID: 6279386341201402954}
+  m_Father: {fileID: 78072048217288069}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6905706939358742202
 GameObject:
   m_ObjectHideFlags: 0
@@ -68663,6 +68698,7 @@ Transform:
   - {fileID: 7837440116578643670}
   - {fileID: 7750772647307061670}
   - {fileID: 4833943421993239440}
+  - {fileID: 4905704404817845342}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &9032849330695138453
@@ -70438,7 +70474,7 @@ PrefabInstance:
     - target: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -16.08999
+      value: -16.157
       objectReference: {fileID: 0}
     - target: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
         type: 3}
@@ -75818,142 +75854,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 180045578567833781}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &192299423456256920
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4355120117052533911}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 2.0000007
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.0000013113022
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 4.015391
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: cb73e949d5f707a45807c2e91cb3f607, type: 2}
-    - target: {fileID: -5754084199372789682, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1568016432510859342, guid: d708dcc33c94fe74a9a4472849f25ac2,
-        type: 3}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Name
-      value: MazeWall02 (55)
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 2147483647
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1587528827798587023}
-  m_SourcePrefab: {fileID: 100100000, guid: f97a1a6d9318ca9408ec24347cd0579b, type: 3}
---- !u!4 &369741794354791539 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-    type: 3}
-  m_PrefabInstance: {fileID: 192299423456256920}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1038720314614374089 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-    type: 3}
-  m_PrefabInstance: {fileID: 192299423456256920}
-  m_PrefabAsset: {fileID: 0}
---- !u!65 &1587528827798587023
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1038720314614374089}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.10113699, y: 0.020000005, z: 0.0031145515}
-  m_Center: {x: 0.03056855, y: 0.010000001, z: -0.0015572758}
 --- !u!1001 &198126547587522979
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -77456,6 +77356,85 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
     type: 3}
   m_PrefabInstance: {fileID: 245379271149621542}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &252775750486794767
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7624238766006415125}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 108.8
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.139687
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.6789999
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -34.180466
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.2862956
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.2862935
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.6465574
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.64655584
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 132.232
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_Name
+      value: MazeSeparator (16)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fc09ef8a6264634098fba0cd8faf1ea, type: 3}
+--- !u!4 &290679305588196836 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+    type: 3}
+  m_PrefabInstance: {fileID: 252775750486794767}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &252919505547919804
 PrefabInstance:
@@ -79312,6 +79291,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
     - target: {fileID: 9011679252773939178, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
       propertyPath: m_VersionIndex
@@ -80059,6 +80043,90 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
     type: 3}
   m_PrefabInstance: {fileID: 329112628092382695}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &335356421214067864
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8569300217519215221}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.276001
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.16299975
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0660033
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.14
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_Name
+      value: DoorWoodPlank (70)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a62d7de514b46e408bc8fe14039fa9b, type: 3}
+--- !u!4 &229074031068920691 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 335356421214067864}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &340238840512554515
 PrefabInstance:
@@ -81179,12 +81247,12 @@ PrefabInstance:
       value: 2147483647
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 8179676008260241022, guid: 13151925fb7703d46be0797c78c1ff06,
-        type: 3}
-      insertIndex: 0
-      addedObject: {fileID: 187327765607653974}
+    m_RemovedGameObjects:
+    - {fileID: 3777967060362578151, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
+    - {fileID: 8972184171757619069, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
+    - {fileID: 3726199393803044583, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
+    - {fileID: 6418961076183134416, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
 --- !u!4 &8397890810558966756 stripped
@@ -81193,147 +81261,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 364587950312353178}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &365702932938737085
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 8397890810558966756}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -7.472
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -1.945
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 270
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -180
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 58380bee58ab3f44fbdf42be465a59f5, type: 2}
-    - target: {fileID: -7511558181221131132, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_Materials.Array.data[1]
-      value: 
-      objectReference: {fileID: 2100000, guid: f8a15662472d0664989087acfe6cec59, type: 2}
-    - target: {fileID: -5754084199372789682, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: -2104641141504007870, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-    - target: {fileID: 919132149155446097, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_Name
-      value: MazeWall01 (15)
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 2147483647
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4986147886344649774}
-  m_SourcePrefab: {fileID: 100100000, guid: ac7029d3d477d4b4caa747593cb709c9, type: 3}
---- !u!4 &187327765607653974 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-    type: 3}
-  m_PrefabInstance: {fileID: 365702932938737085}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &707721758902122732 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: ac7029d3d477d4b4caa747593cb709c9,
-    type: 3}
-  m_PrefabInstance: {fileID: 365702932938737085}
-  m_PrefabAsset: {fileID: 0}
---- !u!65 &4986147886344649774
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 707721758902122732}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.00029251832, y: 0.02000002, z: 0.025000015}
-  m_Center: {x: -0.0011287301, y: 0.010000004, z: 0.012499996}
 --- !u!1001 &366979418380536771
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -82992,6 +82919,14 @@ PrefabInstance:
         type: 3}
       insertIndex: 12
       addedObject: {fileID: 3556945852916631434}
+    - targetCorrespondingSourceObject: {fileID: 1049138787884470938, guid: 5431725e52cdb364994f427d60bf88ba,
+        type: 3}
+      insertIndex: 13
+      addedObject: {fileID: 902590041554074827}
+    - targetCorrespondingSourceObject: {fileID: 1049138787884470938, guid: 5431725e52cdb364994f427d60bf88ba,
+        type: 3}
+      insertIndex: 14
+      addedObject: {fileID: 8898523202473114758}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5431725e52cdb364994f427d60bf88ba, type: 3}
 --- !u!4 &821833199423807268 stripped
@@ -85885,7 +85820,7 @@ PrefabInstance:
     - target: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -16.09
+      value: -16.166
       objectReference: {fileID: 0}
     - target: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
         type: 3}
@@ -102976,6 +102911,100 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 791789249975122116}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &796043812171406112
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 821833199423807268}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.7956963
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.24349415
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071069
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.000000029802322
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.000000014901099
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_Name
+      value: MazeFloor01 (37)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d708dcc33c94fe74a9a4472849f25ac2, type: 3}
+--- !u!4 &902590041554074827 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+    type: 3}
+  m_PrefabInstance: {fileID: 796043812171406112}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &798285670704384111
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -105150,9 +105179,19 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.y
       value: 57.753
       objectReference: {fileID: 0}
+    - target: {fileID: 8404650066353668162, guid: 657010d068ffc8244bbf26d2243abaed,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 8404650066353668162, guid: 657010d068ffc8244bbf26d2243abaed, type: 3}
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 3292551387319426650, guid: 657010d068ffc8244bbf26d2243abaed,
+        type: 3}
+      insertIndex: 2
+      addedObject: {fileID: 6200296895402636266}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 657010d068ffc8244bbf26d2243abaed, type: 3}
 --- !u!4 &2426954984844834795 stripped
@@ -110753,7 +110792,9 @@ PrefabInstance:
       value: 2147483647
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 3777967060362578151, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
+    - {fileID: 8972184171757619069, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
@@ -110999,7 +111040,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -85.148
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: -3591874032358365996, guid: b4eb3bc9e04b52c48a7d09f772c0d493, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -112996,6 +113038,90 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1182943543954688206}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1182991163278498177
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8569300217519215221}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.026001
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.163
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.445
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.14
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_Name
+      value: DoorWoodPlank (66)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a62d7de514b46e408bc8fe14039fa9b, type: 3}
+--- !u!4 &1720495233073512042 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1182991163278498177}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1187928265874006938
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -114912,6 +115038,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3532371243304367222, guid: 5431725e52cdb364994f427d60bf88ba,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.456
+      objectReference: {fileID: 0}
     - target: {fileID: 4037982505971391536, guid: 5431725e52cdb364994f427d60bf88ba,
         type: 3}
       propertyPath: m_Mode
@@ -114945,6 +115076,7 @@ PrefabInstance:
     - {fileID: 2955135714909992657, guid: 5431725e52cdb364994f427d60bf88ba, type: 3}
     - {fileID: 8430743722145091312, guid: 5431725e52cdb364994f427d60bf88ba, type: 3}
     - {fileID: 5152659047005420456, guid: 5431725e52cdb364994f427d60bf88ba, type: 3}
+    - {fileID: 4201383749621280460, guid: 5431725e52cdb364994f427d60bf88ba, type: 3}
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 1049138787884470938, guid: 5431725e52cdb364994f427d60bf88ba,
         type: 3}
@@ -118726,6 +118858,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Hall (8)
       objectReference: {fileID: 0}
+    - target: {fileID: 533689234385008336, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.259
+      objectReference: {fileID: 0}
     - target: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -118776,10 +118913,30 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3106235287922981168, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.259
+      objectReference: {fileID: 0}
+    - target: {fileID: 3497611923413367001, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.627
+      objectReference: {fileID: 0}
+    - target: {fileID: 3497611923413367001, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.259
+      objectReference: {fileID: 0}
     - target: {fileID: 4161156143747160121, guid: e2ff6917c09f07a4183ea1b72f332930,
         type: 3}
       propertyPath: m_VersionIndex
       value: 2129
+      objectReference: {fileID: 0}
+    - target: {fileID: 5330325993685545160, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.259
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
@@ -121985,6 +122142,26 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4499578185304276710, guid: e426e23efd8cb0947b61c6c876d956a3,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 100.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4499578185304276710, guid: e426e23efd8cb0947b61c6c876d956a3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.391
+      objectReference: {fileID: 0}
+    - target: {fileID: 4499578185304276710, guid: e426e23efd8cb0947b61c6c876d956a3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.24349
+      objectReference: {fileID: 0}
+    - target: {fileID: 4499578185304276710, guid: e426e23efd8cb0947b61c6c876d956a3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.746
+      objectReference: {fileID: 0}
     - target: {fileID: 4658145392077450417, guid: e426e23efd8cb0947b61c6c876d956a3,
         type: 3}
       propertyPath: m_Mode
@@ -124116,6 +124293,90 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
     type: 3}
   m_PrefabInstance: {fileID: 1563667840958007008}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1563927091341640769
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8569300217519215221}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.223999
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.16299975
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.4450011
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.14
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_Name
+      value: DoorWoodPlank (62)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a62d7de514b46e408bc8fe14039fa9b, type: 3}
+--- !u!4 &1314653180469584810 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1563927091341640769}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1571587548534660755
 PrefabInstance:
@@ -126510,6 +126771,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: 90-Turn (18)
       objectReference: {fileID: 0}
+    - target: {fileID: 1008447717043778073, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.002012
+      objectReference: {fileID: 0}
     - target: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -126560,6 +126826,46 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1581491000944428153, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.002012
+      objectReference: {fileID: 0}
+    - target: {fileID: 2997055085594966897, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.002
+      objectReference: {fileID: 0}
+    - target: {fileID: 5457516202313491276, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.002012
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8367536998329561364, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 101.04741
+      objectReference: {fileID: 0}
+    - target: {fileID: 8367536998329561364, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8367536998329561364, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.0044
+      objectReference: {fileID: 0}
+    - target: {fileID: 8864620886755439282, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.002012
+      objectReference: {fileID: 0}
     - target: {fileID: 9011679252773939178, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
       propertyPath: m_VersionIndex
@@ -126568,31 +126874,12 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 3115161575152396763, guid: 62496520266653e41b234104c17c2b0e, type: 3}
+    - {fileID: 6126870301348773893, guid: 62496520266653e41b234104c17c2b0e, type: 3}
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 8
-      addedObject: {fileID: 3516117803931774233}
-    - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
-        type: 3}
-      insertIndex: 11
-      addedObject: {fileID: 5478636201699460741}
-    - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
-        type: 3}
-      insertIndex: 14
-      addedObject: {fileID: 7172815588780043526}
-    - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
-        type: 3}
-      insertIndex: 17
-      addedObject: {fileID: 5451302029754691848}
-    - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
-        type: 3}
-      insertIndex: 18
-      addedObject: {fileID: 8111511069977755727}
-    - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
-        type: 3}
-      insertIndex: 23
-      addedObject: {fileID: 5762761820977693883}
+      insertIndex: 19
+      addedObject: {fileID: 5630804492068006510}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 62496520266653e41b234104c17c2b0e, type: 3}
 --- !u!4 &528980670131870569 stripped
@@ -128069,7 +128356,7 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 124.99875
+      value: 125.67374
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
         type: 3}
@@ -128079,12 +128366,12 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.25000066
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.33099997
+      value: 0.332
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
         type: 3}
@@ -133545,6 +133832,100 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1875511068964953819}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1879257951839293005
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8569300217519215221}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 430
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 85
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.503006
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.125
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.875
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_Name
+      value: DoorWoodPlank (51)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a62d7de514b46e408bc8fe14039fa9b, type: 3}
+--- !u!4 &2134370167852427686 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1879257951839293005}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1880670767486691167
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -136834,6 +137215,26 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6795039855714278079, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.998
+      objectReference: {fileID: 0}
+    - target: {fileID: 6795039855714278079, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.986
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.985
       objectReference: {fileID: 0}
     - target: {fileID: 9011679252773939178, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
@@ -146457,7 +146858,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: SM_Trash_5v2
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 3884082904122882362, guid: 8cf84a4e69ba70442a92c060e46e9769, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -157370,12 +157772,13 @@ PrefabInstance:
       value: 2147483647
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 8179676008260241022, guid: 13151925fb7703d46be0797c78c1ff06,
-        type: 3}
-      insertIndex: 0
-      addedObject: {fileID: 6240354752242243564}
+    m_RemovedGameObjects:
+    - {fileID: 3777967060362578151, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
+    - {fileID: 8972184171757619069, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
+    - {fileID: 2966662503493226708, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
+    - {fileID: 2968775630556303163, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
+    - {fileID: 7181435511354218799, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 13151925fb7703d46be0797c78c1ff06, type: 3}
 --- !u!4 &6257378604268088476 stripped
@@ -161666,6 +162069,90 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2960430381710741771}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2971462928784841467
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8569300217519215221}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.026001
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.163
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0660021
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.14
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_Name
+      value: DoorWoodPlank (71)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a62d7de514b46e408bc8fe14039fa9b, type: 3}
+--- !u!4 &3366010499749330192 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 2971462928784841467}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2978034020048098719
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -162278,6 +162765,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.985
       objectReference: {fileID: 0}
     - target: {fileID: 9011679252773939178, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
@@ -165242,6 +165739,116 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 3106268464850559684}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3117773608408261922
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5337458985461301983}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 97.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.644
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.081
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.0000020712612
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.0000020787118
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071067
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.7071069
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: cb73e949d5f707a45807c2e91cb3f607, type: 2}
+    - target: {fileID: -5754084199372789682, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1568016432510859342, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_Name
+      value: MazeWall02 (21)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f97a1a6d9318ca9408ec24347cd0579b, type: 3}
+--- !u!4 &3228579458851947209 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+    type: 3}
+  m_PrefabInstance: {fileID: 3117773608408261922}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3123430331378478499
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -165982,6 +166589,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.y
       value: 82.23876
+      objectReference: {fileID: 0}
+    - target: {fileID: 6795039855714278079, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6795039855714278079, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.985
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 7795701648306785480, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
@@ -168864,7 +169486,7 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 100
+      value: 97.5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
         type: 3}
@@ -168874,17 +169496,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -2.6440156
+      value: -2.644
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.24999964
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.08100021
+      value: 0.081
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
         type: 3}
@@ -169450,6 +170072,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
     - target: {fileID: 7639188662375736849, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
       propertyPath: m_LocalScale.x
@@ -169529,146 +170156,142 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
       insertIndex: 38
-      addedObject: {fileID: 369741794354791539}
-    - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
-        type: 3}
-      insertIndex: 39
       addedObject: {fileID: 8232186207638409056}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 40
+      insertIndex: 39
       addedObject: {fileID: 9082707779085218707}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 41
+      insertIndex: 40
       addedObject: {fileID: 3151202148770011070}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 42
+      insertIndex: 41
       addedObject: {fileID: 7709829270803946589}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 43
+      insertIndex: 42
       addedObject: {fileID: 2832439892372988216}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 44
+      insertIndex: 43
       addedObject: {fileID: 2383243179680623509}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 45
+      insertIndex: 44
       addedObject: {fileID: 5434694093899359626}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 46
+      insertIndex: 45
       addedObject: {fileID: 7930660509508606472}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 47
+      insertIndex: 46
       addedObject: {fileID: 6049922970786418881}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 48
+      insertIndex: 47
       addedObject: {fileID: 1896144234553128589}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 49
+      insertIndex: 48
       addedObject: {fileID: 8687321622831825990}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 50
+      insertIndex: 49
       addedObject: {fileID: 7936977989133213760}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 51
+      insertIndex: 50
       addedObject: {fileID: 5604164825020351501}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 52
+      insertIndex: 51
       addedObject: {fileID: 4618175379668569083}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 53
+      insertIndex: 52
       addedObject: {fileID: 109383330796722394}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 54
+      insertIndex: 53
       addedObject: {fileID: 4997525131845197623}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 55
+      insertIndex: 54
       addedObject: {fileID: 5665633495157379678}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 56
+      insertIndex: 55
       addedObject: {fileID: 9010522083939579550}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 57
+      insertIndex: 56
       addedObject: {fileID: 9018436617608848135}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 58
+      insertIndex: 57
       addedObject: {fileID: 7618654223718912670}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 59
+      insertIndex: 58
       addedObject: {fileID: 9194996244501669097}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 60
+      insertIndex: 59
       addedObject: {fileID: 8206472083559406069}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 61
+      insertIndex: 60
       addedObject: {fileID: 4337701025956222875}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 62
+      insertIndex: 61
       addedObject: {fileID: 5800901172721022888}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 63
+      insertIndex: 62
       addedObject: {fileID: 1476430703712306311}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 64
+      insertIndex: 63
       addedObject: {fileID: 7754195563718838118}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 65
+      insertIndex: 64
       addedObject: {fileID: 5165227721750705124}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 66
+      insertIndex: 65
       addedObject: {fileID: 4827110012896322121}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 67
+      insertIndex: 66
       addedObject: {fileID: 6789070426275972707}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 68
+      insertIndex: 67
       addedObject: {fileID: 422598184676981263}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 69
+      insertIndex: 68
       addedObject: {fileID: 4623110094023707289}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 70
+      insertIndex: 69
       addedObject: {fileID: 8096137523840776931}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 71
+      insertIndex: 70
       addedObject: {fileID: 2825783287057247797}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 72
+      insertIndex: 71
       addedObject: {fileID: 7604227576179023591}
     - targetCorrespondingSourceObject: {fileID: 1278352299857686727, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
-      insertIndex: 73
+      insertIndex: 72
       addedObject: {fileID: 8593646983447100875}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 62496520266653e41b234104c17c2b0e, type: 3}
@@ -179189,6 +179812,116 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 3690729964917024147}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3695239031036533065
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5337458985461301983}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 97.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.644
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.081
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.0000020712612
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.0000020787118
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071067
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.7071069
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: cb73e949d5f707a45807c2e91cb3f607, type: 2}
+    - target: {fileID: -5754084199372789682, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1568016432510859342, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_Name
+      value: MazeWall02 (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f97a1a6d9318ca9408ec24347cd0579b, type: 3}
+--- !u!4 &3801769464537169570 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+    type: 3}
+  m_PrefabInstance: {fileID: 3695239031036533065}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3697540895457723475
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -179252,10 +179985,70 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2957916696851280697, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.011
+      objectReference: {fileID: 0}
+    - target: {fileID: 3197250070359401649, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.011
+      objectReference: {fileID: 0}
+    - target: {fileID: 3214207762651229271, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.011
+      objectReference: {fileID: 0}
+    - target: {fileID: 6701940379703459282, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.011
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.011
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.985
+      objectReference: {fileID: 0}
+    - target: {fileID: 7599792486934187634, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.011
+      objectReference: {fileID: 0}
+    - target: {fileID: 7629417321867012780, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.011
+      objectReference: {fileID: 0}
     - target: {fileID: 7795701648306785480, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
       propertyPath: m_LocalScale.y
       value: 83.83054
+      objectReference: {fileID: 0}
+    - target: {fileID: 7795701648306785480, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.011
+      objectReference: {fileID: 0}
+    - target: {fileID: 8510331816473730611, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.011
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931448425069236757, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.011
       objectReference: {fileID: 0}
     - target: {fileID: 9011679252773939178, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
@@ -187734,147 +188527,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 3981448544520542078}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &3981599876650289906
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 528980670131870569}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: -100
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -7.999954
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.456498
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -11.984716
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 3f39bf1583e0080408e517f1dd9ae0d8, type: 2}
-    - target: {fileID: -5754084199372789682, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1568016432510859342, guid: d708dcc33c94fe74a9a4472849f25ac2,
-        type: 3}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Name
-      value: MazeWall02 (38)
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 2147483647
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4814665186479974472}
-  m_SourcePrefab: {fileID: 100100000, guid: f97a1a6d9318ca9408ec24347cd0579b, type: 3}
---- !u!4 &3516117803931774233 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-    type: 3}
-  m_PrefabInstance: {fileID: 3981599876650289906}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &4287446842246428579 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-    type: 3}
-  m_PrefabInstance: {fileID: 3981599876650289906}
-  m_PrefabAsset: {fileID: 0}
---- !u!65 &4814665186479974472
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4287446842246428579}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.020000003, y: 0.10041214, z: 0.000530178}
-  m_Center: {x: -0.010000001, y: -0.03020618, z: 0.00026508904}
 --- !u!1001 &3982268172529786022
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -197602,7 +198254,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: -3591874032358365996, guid: b4eb3bc9e04b52c48a7d09f772c0d493, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -199198,6 +199851,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.985
       objectReference: {fileID: 0}
     - target: {fileID: 9011679252773939178, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
@@ -210104,15 +210767,23 @@ PrefabInstance:
       addedObject: {fileID: 3026815140856563054}
     - targetCorrespondingSourceObject: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
         type: 3}
-      insertIndex: 8
-      addedObject: {fileID: 811252784721742021}
+      insertIndex: 7
+      addedObject: {fileID: 3228579458851947209}
     - targetCorrespondingSourceObject: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
         type: 3}
-      insertIndex: 9
-      addedObject: {fileID: 6454732860993095285}
+      insertIndex: 8
+      addedObject: {fileID: 3801769464537169570}
     - targetCorrespondingSourceObject: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
         type: 3}
       insertIndex: 10
+      addedObject: {fileID: 811252784721742021}
+    - targetCorrespondingSourceObject: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      insertIndex: 11
+      addedObject: {fileID: 6454732860993095285}
+    - targetCorrespondingSourceObject: {fileID: 1081506557531602852, guid: e2ff6917c09f07a4183ea1b72f332930,
+        type: 3}
+      insertIndex: 12
       addedObject: {fileID: 7970112658610991904}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e2ff6917c09f07a4183ea1b72f332930, type: 3}
@@ -210329,6 +211000,90 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
     type: 3}
   m_PrefabInstance: {fileID: 4980819912985811831}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4984005426039706199
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8569300217519215221}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.47399902
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.16299975
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.4450011
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.14
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_Name
+      value: DoorWoodPlank (63)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a62d7de514b46e408bc8fe14039fa9b, type: 3}
+--- !u!4 &4800845973889365436 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 4984005426039706199}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4984422036353841335
 PrefabInstance:
@@ -223366,116 +224121,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 5214982605388069844}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &5220736456409113424
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 528980670131870569}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: -100
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.000047434132
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.456498
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -11.984724
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 3f39bf1583e0080408e517f1dd9ae0d8, type: 2}
-    - target: {fileID: -5754084199372789682, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1568016432510859342, guid: d708dcc33c94fe74a9a4472849f25ac2,
-        type: 3}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Name
-      value: MazeWall02 (42)
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 2147483647
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f97a1a6d9318ca9408ec24347cd0579b, type: 3}
---- !u!4 &5762761820977693883 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-    type: 3}
-  m_PrefabInstance: {fileID: 5220736456409113424}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5224191836149942472
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -226394,6 +227039,121 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
     type: 3}
   m_PrefabInstance: {fileID: 5307538566506842380}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5309211416196959621
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 528980670131870569}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 101.04741
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 99.999985
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: -100
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.000031936925
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.456498
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.0044
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.50000143
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.50000143
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.49999857
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49999857
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 3f39bf1583e0080408e517f1dd9ae0d8, type: 2}
+    - target: {fileID: -5754084199372789682, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1568016432510859342, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_Name
+      value: MazeWall02 (37)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f97a1a6d9318ca9408ec24347cd0579b, type: 3}
+--- !u!4 &5630804492068006510 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
+    type: 3}
+  m_PrefabInstance: {fileID: 5309211416196959621}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5314056957657996352
 PrefabInstance:
@@ -230446,116 +231206,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 5440208105678233409}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &5441122287155224942
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 528980670131870569}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: -100
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -5.999961
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.456498
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -11.984724
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 3f39bf1583e0080408e517f1dd9ae0d8, type: 2}
-    - target: {fileID: -5754084199372789682, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1568016432510859342, guid: d708dcc33c94fe74a9a4472849f25ac2,
-        type: 3}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Name
-      value: MazeWall02 (39)
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 2147483647
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f97a1a6d9318ca9408ec24347cd0579b, type: 3}
---- !u!4 &5478636201699460741 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-    type: 3}
-  m_PrefabInstance: {fileID: 5441122287155224942}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5455042359630633170
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -231339,116 +231989,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
     type: 3}
   m_PrefabInstance: {fileID: 5487271621192268965}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &5488853499273385699
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 528980670131870569}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: -100
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.9999528
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.456498
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -11.984724
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 3f39bf1583e0080408e517f1dd9ae0d8, type: 2}
-    - target: {fileID: -5754084199372789682, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1568016432510859342, guid: d708dcc33c94fe74a9a4472849f25ac2,
-        type: 3}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Name
-      value: MazeWall02 (41)
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 2147483647
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f97a1a6d9318ca9408ec24347cd0579b, type: 3}
---- !u!4 &5451302029754691848 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-    type: 3}
-  m_PrefabInstance: {fileID: 5488853499273385699}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5491386245668233793
 PrefabInstance:
@@ -232401,6 +232941,80 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
     type: 3}
   m_PrefabInstance: {fileID: 5512672521394091746}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5526987219996878158
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 4905704404817845342}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 90.47499
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.733
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -206.207
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9228511
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.3851571
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -45.307
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_Name
+      value: Harpoon_Blade_LP (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 403fc293ebbbab84492f1152ac2cc7cf, type: 3}
+--- !u!4 &5420492177450255013 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+    type: 3}
+  m_PrefabInstance: {fileID: 5526987219996878158}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5531733424260319303
 PrefabInstance:
@@ -240216,6 +240830,80 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 5809426742611936580}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5813696211458374561
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 4905704404817845342}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 61.671997
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.6
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -212.845
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.38009724
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.9249466
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 135.321
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_Name
+      value: Harpoon_Blade_LP (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 403fc293ebbbab84492f1152ac2cc7cf, type: 3}
+--- !u!4 &6279386341201402954 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+    type: 3}
+  m_PrefabInstance: {fileID: 5813696211458374561}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5815304680878283647
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -241296,147 +241984,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 5836418089911105399}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &5841319250629537799
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 6257378604268088476}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.020996094
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.010000005
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -2.1399994
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 270
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -180
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 58380bee58ab3f44fbdf42be465a59f5, type: 2}
-    - target: {fileID: -7511558181221131132, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_Materials.Array.data[1]
-      value: 
-      objectReference: {fileID: 2100000, guid: f8a15662472d0664989087acfe6cec59, type: 2}
-    - target: {fileID: -5754084199372789682, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: -2104641141504007870, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-    - target: {fileID: 919132149155446097, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_Name
-      value: MazeWall01 (14)
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 2147483647
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: ac7029d3d477d4b4caa747593cb709c9,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7738748819109052632}
-  m_SourcePrefab: {fileID: 100100000, guid: ac7029d3d477d4b4caa747593cb709c9, type: 3}
---- !u!4 &6240354752242243564 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ac7029d3d477d4b4caa747593cb709c9,
-    type: 3}
-  m_PrefabInstance: {fileID: 5841319250629537799}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &6760432150813707606 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: ac7029d3d477d4b4caa747593cb709c9,
-    type: 3}
-  m_PrefabInstance: {fileID: 5841319250629537799}
-  m_PrefabAsset: {fileID: 0}
---- !u!65 &7738748819109052632
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6760432150813707606}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.00029251832, y: 0.02000002, z: 0.025000015}
-  m_Center: {x: -0.0011287301, y: 0.010000004, z: 0.012499996}
 --- !u!1001 &5842078669051561344
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -242666,6 +243213,100 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 5868801517829625350}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5869477215571111533
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8569300217519215221}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 430
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 85
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.503
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.125
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.625
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_Name
+      value: DoorWoodPlank (50)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a62d7de514b46e408bc8fe14039fa9b, type: 3}
+--- !u!4 &6268495094062516614 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 5869477215571111533}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5876073180516326893
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -243431,6 +244072,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.985
       objectReference: {fileID: 0}
     - target: {fileID: 9011679252773939178, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
@@ -244907,6 +245558,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.y
       value: 74.369995
       objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.999
+      objectReference: {fileID: 0}
     - target: {fileID: 9011679252773939178, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
       propertyPath: m_VersionIndex
@@ -246179,6 +246835,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 9011679252773939178, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
@@ -250100,6 +250761,90 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
     type: 3}
   m_PrefabInstance: {fileID: 6163353931862729310}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6163496782947434519
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8569300217519215221}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.776001
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.16299975
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0660033
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.14
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_Name
+      value: DoorWoodPlank (69)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a62d7de514b46e408bc8fe14039fa9b, type: 3}
+--- !u!4 &5909737381554366460 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 6163496782947434519}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6169197549578900874
 PrefabInstance:
@@ -258815,6 +259560,85 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6452030680220267279}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6463309293311049684
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7624238766006415125}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 108.8
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.139
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.679
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -36.202
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.2547426
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.25474298
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.6596271
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.65962446
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 222.232
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_Name
+      value: MazeSeparator (15)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fc09ef8a6264634098fba0cd8faf1ea, type: 3}
+--- !u!4 &6789441367345223743 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+    type: 3}
+  m_PrefabInstance: {fileID: 6463309293311049684}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6465954374018143957
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -262421,6 +263245,90 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
     type: 3}
   m_PrefabInstance: {fileID: 6586922930974474800}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6587327303370705956
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8569300217519215221}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.776001
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.16299975
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.4450011
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.14
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_Name
+      value: DoorWoodPlank (64)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a62d7de514b46e408bc8fe14039fa9b, type: 3}
+--- !u!4 &6692448232067951567 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 6587327303370705956}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6598724340920180579
 PrefabInstance:
@@ -280919,116 +281827,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 7191402315367661792}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &7205843770475219693
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 528980670131870569}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: -100
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.9999533
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.456498
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -11.984724
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 3f39bf1583e0080408e517f1dd9ae0d8, type: 2}
-    - target: {fileID: -5754084199372789682, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1568016432510859342, guid: d708dcc33c94fe74a9a4472849f25ac2,
-        type: 3}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Name
-      value: MazeWall02 (40)
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 2147483647
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f97a1a6d9318ca9408ec24347cd0579b, type: 3}
---- !u!4 &7172815588780043526 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-    type: 3}
-  m_PrefabInstance: {fileID: 7205843770475219693}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7207765153790201169
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -281092,7 +281890,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: SM_Trash_1
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 8140154613885259717, guid: eb20870e82297b24abea7f531492dbf6, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -281914,6 +282713,92 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
     type: 3}
   m_PrefabInstance: {fileID: 7236426520079269549}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7237205674230315582
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2426954984844834795}
+    m_Modifications:
+    - target: {fileID: 1058631376482529418, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3631125169426008532, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 31.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 3631125169426008532, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.027
+      objectReference: {fileID: 0}
+    - target: {fileID: 3631125169426008532, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -23.348
+      objectReference: {fileID: 0}
+    - target: {fileID: 3631125169426008532, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3631125169426008532, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3631125169426008532, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3631125169426008532, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3631125169426008532, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3631125169426008532, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3631125169426008532, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7995284102956317724, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8712452120125739766, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoRack
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 1058631376482529418, guid: 6f25fb14f9e9a174abbfc4b363393fd4, type: 3}
+    - {fileID: 7995284102956317724, guid: 6f25fb14f9e9a174abbfc4b363393fd4, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6f25fb14f9e9a174abbfc4b363393fd4, type: 3}
+--- !u!4 &6200296895402636266 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3631125169426008532, guid: 6f25fb14f9e9a174abbfc4b363393fd4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7237205674230315582}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7237696645943020914
 PrefabInstance:
@@ -285298,6 +286183,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 78072048217288069}
     m_Modifications:
+    - target: {fileID: 144945084025081530, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.755005
+      objectReference: {fileID: 0}
     - target: {fileID: 203863309064267659, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -285307,6 +286197,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: HotfixThings
+      objectReference: {fileID: 0}
+    - target: {fileID: 416976532366536050, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 752070945228276173, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
@@ -285358,6 +286253,31 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1003057394714407613, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.495
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045597482891999176, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.005005
+      objectReference: {fileID: 0}
+    - target: {fileID: 1166214034928211137, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.24499512
+      objectReference: {fileID: 0}
+    - target: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.955
+      objectReference: {fileID: 0}
+    - target: {fileID: 1173576708568450857, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.25500488
+      objectReference: {fileID: 0}
     - target: {fileID: 1461691320408684251, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: _onPlayerCollision.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
@@ -285388,26 +286308,96 @@ PrefabInstance:
       propertyPath: _onPlayerCollision.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
+    - target: {fileID: 1702618496337581069, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.244995
+      objectReference: {fileID: 0}
+    - target: {fileID: 1859711082494712946, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.49499512
+      objectReference: {fileID: 0}
+    - target: {fileID: 1981207415422130637, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.7449951
+      objectReference: {fileID: 0}
+    - target: {fileID: 2013908568407921435, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.255005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2083182813302150814, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 73.38761
+      objectReference: {fileID: 0}
+    - target: {fileID: 2083182813302150814, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.54
+      objectReference: {fileID: 0}
     - target: {fileID: 2414325078760780295, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 269.481
       objectReference: {fileID: 0}
+    - target: {fileID: 2745175569040509523, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2766256862192641942, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.494995
+      objectReference: {fileID: 0}
+    - target: {fileID: 3003936134984565615, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.49499512
+      objectReference: {fileID: 0}
     - target: {fileID: 3112595355962201994, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1493
+      value: 1511
       objectReference: {fileID: 0}
     - target: {fileID: 3130528783893527292, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: m_VersionIndex
-      value: 1517
+      value: 1535
       objectReference: {fileID: 0}
     - target: {fileID: 3135790209192228888, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: _onPlayerCollision.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 2662689105212598882}
+    - target: {fileID: 3265956414799859945, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.994995
+      objectReference: {fileID: 0}
+    - target: {fileID: 3539016522918737169, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.744995
+      objectReference: {fileID: 0}
+    - target: {fileID: 3649128700764258425, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.2449951
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715183421980928862, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3782262293194113891, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3817435561709862531, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: _onPlayerCollision.m_PersistentCalls.m_Calls.Array.size
@@ -285463,15 +286453,65 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.y
       value: -36.835
       objectReference: {fileID: 0}
+    - target: {fileID: 3993884239174939531, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.9949951
+      objectReference: {fileID: 0}
+    - target: {fileID: 4554998672110180825, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.005004883
+      objectReference: {fileID: 0}
+    - target: {fileID: 4709750565388437769, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.7550049
+      objectReference: {fileID: 0}
     - target: {fileID: 4841078023949762835, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4866112735464613608, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.994995
+      objectReference: {fileID: 0}
+    - target: {fileID: 5045969524007418998, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.494995
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178436481713989961, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.244995
+      objectReference: {fileID: 0}
+    - target: {fileID: 5297034615248586959, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.005005
+      objectReference: {fileID: 0}
+    - target: {fileID: 5383502124502898296, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.255005
+      objectReference: {fileID: 0}
     - target: {fileID: 5660486223762507176, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5708365591524399343, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.7449951
+      objectReference: {fileID: 0}
+    - target: {fileID: 5709899136060455442, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.755
       objectReference: {fileID: 0}
     - target: {fileID: 5764949689296870605, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
@@ -285543,10 +286583,25 @@ PrefabInstance:
       propertyPath: _onTriggerEvents.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
+    - target: {fileID: 5832075671766471698, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.494995
+      objectReference: {fileID: 0}
     - target: {fileID: 5849347750907495128, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5919017307575129806, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.994995
+      objectReference: {fileID: 0}
+    - target: {fileID: 5920658547356810274, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.0050049
       objectReference: {fileID: 0}
     - target: {fileID: 6085656907657010369, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
@@ -285693,6 +286748,36 @@ PrefabInstance:
       propertyPath: _onPlayerCollision.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
+    - target: {fileID: 6122792482134056698, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.505005
+      objectReference: {fileID: 0}
+    - target: {fileID: 6314594872805751664, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.255005
+      objectReference: {fileID: 0}
+    - target: {fileID: 6335251172576564903, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.5050049
+      objectReference: {fileID: 0}
+    - target: {fileID: 6436584319780142420, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.7550049
+      objectReference: {fileID: 0}
+    - target: {fileID: 6440630397375440536, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6444442490804620404, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6511594345891477530, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: m_Size.z
@@ -285708,10 +286793,50 @@ PrefabInstance:
       propertyPath: m_Center.z
       value: 0.10658649
       objectReference: {fileID: 0}
+    - target: {fileID: 6606379111338460408, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.505005
+      objectReference: {fileID: 0}
     - target: {fileID: 6658756463366460056, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6715285902330215295, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.494995
+      objectReference: {fileID: 0}
+    - target: {fileID: 6848291917004256148, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.994995
+      objectReference: {fileID: 0}
+    - target: {fileID: 7163361829797714181, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.9949951
+      objectReference: {fileID: 0}
+    - target: {fileID: 7175934678411462827, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.5050049
+      objectReference: {fileID: 0}
+    - target: {fileID: 7430008028132832990, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.755005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7435607797560857271, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.0050049
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503717215487591359, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7562106850059293525, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
@@ -285728,11 +286853,31 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 150
       objectReference: {fileID: 0}
+    - target: {fileID: 7581682067712158883, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.005004883
+      objectReference: {fileID: 0}
     - target: {fileID: 8288830710109873711, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: _onPlayerCollision.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
       objectReference: {fileID: 5895103414703959338}
+    - target: {fileID: 8442169075274484321, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 73.38761
+      objectReference: {fileID: 0}
+    - target: {fileID: 8442169075274484321, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.5209923
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472314344679500736, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.2550049
+      objectReference: {fileID: 0}
     - target: {fileID: 8699033366630688826, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -285743,6 +286888,21 @@ PrefabInstance:
       propertyPath: m_Range
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 8987552890167219439, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.494995
+      objectReference: {fileID: 0}
+    - target: {fileID: 9209654927202117156, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 117.944
+      objectReference: {fileID: 0}
+    - target: {fileID: 9209654927202117156, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.397
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 8536038933718441164, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
     - {fileID: 422262607127605555, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
@@ -285752,7 +286912,23 @@ PrefabInstance:
     - {fileID: 5687780341624543843, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
     - {fileID: 925681106318288815, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
     - {fileID: 4011004107800454989, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 5518686524822795251, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 3782262293194113891, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 3715183421980928862, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 7503717215487591359, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 6444442490804620404, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 416976532366536050, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 2745175569040509523, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 6440630397375440536, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 7096647199917798937, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 4334415722571491633, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 3205155280991797426, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 5245628606481120338, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 4812386775549301365, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 7816917762026833933, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 6071368631911442734, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
+    - {fileID: 8395999364333354142, guid: 4890d7ba2a262954a97d52948971a667, type: 3}
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 625598241826098152, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
@@ -285766,6 +286942,14 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 922440304868562590}
+    - targetCorrespondingSourceObject: {fileID: 1109422676922499086, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 10
+      addedObject: {fileID: 6789441367345223743}
+    - targetCorrespondingSourceObject: {fileID: 1109422676922499086, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 11
+      addedObject: {fileID: 290679305588196836}
     - targetCorrespondingSourceObject: {fileID: 7562106850059293525, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
       insertIndex: -1
@@ -285790,6 +286974,54 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 9097266458280546867}
+    - targetCorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 8
+      addedObject: {fileID: 1314653180469584810}
+    - targetCorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 9
+      addedObject: {fileID: 8704510056404586526}
+    - targetCorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 11
+      addedObject: {fileID: 4800845973889365436}
+    - targetCorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 12
+      addedObject: {fileID: 7610720685611218909}
+    - targetCorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 22
+      addedObject: {fileID: 6692448232067951567}
+    - targetCorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 23
+      addedObject: {fileID: 5909737381554366460}
+    - targetCorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 38
+      addedObject: {fileID: 8093650655706924422}
+    - targetCorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 39
+      addedObject: {fileID: 229074031068920691}
+    - targetCorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 41
+      addedObject: {fileID: 1720495233073512042}
+    - targetCorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 42
+      addedObject: {fileID: 3366010499749330192}
+    - targetCorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 45
+      addedObject: {fileID: 6268495094062516614}
+    - targetCorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
+        type: 3}
+      insertIndex: 50
+      addedObject: {fileID: 2134370167852427686}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 552335512791674715, guid: 4890d7ba2a262954a97d52948971a667,
         type: 3}
@@ -285902,6 +287134,12 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!4 &7624238766006415125 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1109422676922499086, guid: 4890d7ba2a262954a97d52948971a667,
+    type: 3}
+  m_PrefabInstance: {fileID: 7398229776200740635}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &7629746934290168253 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1101557411184121510, guid: 4890d7ba2a262954a97d52948971a667,
@@ -285935,6 +287173,12 @@ Transform:
 --- !u!1 &8262260316832516591 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1441920659162818292, guid: 4890d7ba2a262954a97d52948971a667,
+    type: 3}
+  m_PrefabInstance: {fileID: 7398229776200740635}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &8569300217519215221 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1173064480314146158, guid: 4890d7ba2a262954a97d52948971a667,
     type: 3}
   m_PrefabInstance: {fileID: 7398229776200740635}
   m_PrefabAsset: {fileID: 0}
@@ -295035,10 +296279,15 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 8047756848820161186, guid: 870457a27c9f61142aafcc500b4224a6, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4680248550374275037, guid: 870457a27c9f61142aafcc500b4224a6,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5444224872720134401}
   m_SourcePrefab: {fileID: 100100000, guid: 870457a27c9f61142aafcc500b4224a6, type: 3}
 --- !u!4 &2318707372127317970 stripped
 Transform:
@@ -295046,6 +296295,33 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 7752368411351597749}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &3127297756298360168 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4680248550374275037, guid: 870457a27c9f61142aafcc500b4224a6,
+    type: 3}
+  m_PrefabInstance: {fileID: 7752368411351597749}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &5444224872720134401
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3127297756298360168}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 2.257431, y: 1.3752053, z: 0.91091776}
+  m_Center: {x: -0.16480255, y: 0.19085443, z: 0.24525523}
 --- !u!1001 &7760172581861535806
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -299861,15 +301137,30 @@ PrefabInstance:
       propertyPath: m_LocalPosition.y
       value: -0.5
       objectReference: {fileID: 0}
+    - target: {fileID: 4658224298099842669, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.744
+      objectReference: {fileID: 0}
     - target: {fileID: 6795039855714278079, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -2.003
+      value: -1.999
       objectReference: {fileID: 0}
     - target: {fileID: 6795039855714278079, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -8.002
+      value: -8.006
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040556715577607128, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.985
       objectReference: {fileID: 0}
     - target: {fileID: 7795701648306785480, guid: 62496520266653e41b234104c17c2b0e,
         type: 3}
@@ -299901,12 +301192,19 @@ PrefabInstance:
       propertyPath: m_VersionIndex
       value: 1760
       objectReference: {fileID: 0}
+    - target: {fileID: 9035989895508751765, guid: 62496520266653e41b234104c17c2b0e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.124
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 6690548557855829731, guid: 62496520266653e41b234104c17c2b0e, type: 3}
     - {fileID: 2816220172101959179, guid: 62496520266653e41b234104c17c2b0e, type: 3}
     - {fileID: 2512020218085777867, guid: 62496520266653e41b234104c17c2b0e, type: 3}
     - {fileID: 2213876571896635075, guid: 62496520266653e41b234104c17c2b0e, type: 3}
+    - {fileID: 8515629888007384879, guid: 62496520266653e41b234104c17c2b0e, type: 3}
+    - {fileID: 5471459018602300631, guid: 62496520266653e41b234104c17c2b0e, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 8122578005047969967, guid: 62496520266653e41b234104c17c2b0e,
@@ -300144,6 +301442,90 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
     type: 3}
   m_PrefabInstance: {fileID: 7930027282823657740}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7931981742660882486
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8569300217519215221}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.47399902
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.16299975
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.066
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.14
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_Name
+      value: DoorWoodPlank (68)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a62d7de514b46e408bc8fe14039fa9b, type: 3}
+--- !u!4 &7610720685611218909 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 7931981742660882486}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7934246864346670528
 PrefabInstance:
@@ -310380,37 +311762,37 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 117.63901
+      value: 117.629135
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.4419994
+      value: 1.389
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -173.022
+      value: -173.05858
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.61237276
+      value: 0.65403736
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.61237276
+      value: 0.65403736
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.35355285
+      value: 0.268766
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.35355285
+      value: -0.268766
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
         type: 3}
@@ -310425,7 +311807,7 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 120
+      value: 135.321
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
         type: 3}
@@ -313587,7 +314969,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 62.557
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 8047756848820161186, guid: 870457a27c9f61142aafcc500b4224a6, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -313904,6 +315287,85 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6245986809019448971, guid: 22ebc6e1dbbaf67439ebcdea97febc3f,
     type: 3}
   m_PrefabInstance: {fileID: 8176193041645929650}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8177375464391777759
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3540392833910691858}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 117.6587
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.125
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -171.842
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.0000014603136
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_Name
+      value: MazeSeparator (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fc09ef8a6264634098fba0cd8faf1ea, type: 3}
+--- !u!4 &8570744633975142964 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 3fc09ef8a6264634098fba0cd8faf1ea,
+    type: 3}
+  m_PrefabInstance: {fileID: 8177375464391777759}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8178347878010410153
 PrefabInstance:
@@ -332257,6 +333719,80 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 8494517136375308443}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8500664301264069638
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 4905704404817845342}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 84.614
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.621
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -212.924
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.49694538
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.8677818
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 120.404
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+        type: 3}
+      propertyPath: m_Name
+      value: Harpoon_Blade_LP
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 403fc293ebbbab84492f1152ac2cc7cf, type: 3}
+--- !u!4 &8246887349624833005 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 403fc293ebbbab84492f1152ac2cc7cf,
+    type: 3}
+  m_PrefabInstance: {fileID: 8500664301264069638}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8500865171794658623
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -335249,116 +336785,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 8581855083979920275}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &8582551552128001956
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 528980670131870569}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 99.999985
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: -100
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.9999833
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.456498
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -7.984724
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.50000143
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49999857
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 3f39bf1583e0080408e517f1dd9ae0d8, type: 2}
-    - target: {fileID: -5754084199372789682, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1568016432510859342, guid: d708dcc33c94fe74a9a4472849f25ac2,
-        type: 3}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_Name
-      value: MazeWall02 (37)
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: f97a1a6d9318ca9408ec24347cd0579b,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 2147483647
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f97a1a6d9318ca9408ec24347cd0579b, type: 3}
---- !u!4 &8111511069977755727 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f97a1a6d9318ca9408ec24347cd0579b,
-    type: 3}
-  m_PrefabInstance: {fileID: 8582551552128001956}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8586663930777085337
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -336747,6 +338173,90 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 0.10113699, y: 0.020000005, z: 0.0031145515}
   m_Center: {x: 0.03056855, y: 0.010000001, z: -0.0015572758}
+--- !u!1001 &8635886613852430957
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8569300217519215221}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.276001
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.16299975
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.4450011
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.14
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_Name
+      value: DoorWoodPlank (65)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a62d7de514b46e408bc8fe14039fa9b, type: 3}
+--- !u!4 &8093650655706924422 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 8635886613852430957}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8645118827465826721
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -338327,7 +339837,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: SM_Trash_5v2 (1)
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 3884082904122882362, guid: 8cf84a4e69ba70442a92c060e46e9769, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -345641,6 +347152,100 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 9002624494809049343}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &9004770200322988909
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 821833199423807268}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.7956963
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.24349415
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.399
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071069
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.000000029802322
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.000000014901099
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_Name
+      value: MazeFloor01 (36)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d708dcc33c94fe74a9a4472849f25ac2,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d708dcc33c94fe74a9a4472849f25ac2, type: 3}
+--- !u!4 &8898523202473114758 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
+    type: 3}
+  m_PrefabInstance: {fileID: 9004770200322988909}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &9007965767041528918
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -350308,6 +351913,90 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d708dcc33c94fe74a9a4472849f25ac2,
     type: 3}
   m_PrefabInstance: {fileID: 9167103123434856684}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &9171044879964502005
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8569300217519215221}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.223999
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.16299975
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0660033
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70609194
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.03787107
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -6.14
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_Name
+      value: DoorWoodPlank (67)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a62d7de514b46e408bc8fe14039fa9b, type: 3}
+--- !u!4 &8704510056404586526 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0a62d7de514b46e408bc8fe14039fa9b,
+    type: 3}
+  m_PrefabInstance: {fileID: 9171044879964502005}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &9175738262742775051
 PrefabInstance:


### PR DESCRIPTION
The title says it,

There were was a pile of trash that the player could slide ontop in the second split path. Fixed it so that it's now one big box collider to prevent the player from walking ontop of the trash.

https://bradleycapstone.atlassian.net/browse/LV-2183