### PR TITLE
pg-eng-Stuck-harpoons-float-LV-2225

### DIFF
--- a/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/AframaxSceneManager.cs
+++ b/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/AframaxSceneManager.cs
@@ -164,6 +164,8 @@ public class AframaxSceneManager : MainUniversalManagerFramework
     /// </summary>
     public void ReloadTitleScreen()
     {
+        _onBeforeSceneChange?.Invoke();
+
         //destroy all "dont destroy on load" objects
         GameObject dontDestroyFinder = new GameObject();
         DontDestroyOnLoad(dontDestroyFinder);

--- a/Assets/Scripts/Maze/MazeSubSceneManager.cs
+++ b/Assets/Scripts/Maze/MazeSubSceneManager.cs
@@ -1,7 +1,7 @@
 /******************************************************************************
 // File Name:       MazeSubSceneManager.cs
 // Author:          Miles Rogers
-// Contributor:     Ryan Swanson
+// Contributors:     Ryan Swanson, Jeremiah Peters
 // Creation Date:   March 3rd, 2025
 //
 // Description:     Interacts with AframaxSceneManager to additively load
@@ -15,6 +15,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.Serialization;
+using UnityEngine.Events;
 using Debug = System.Diagnostics.Debug;
 
 /// <summary>
@@ -48,7 +49,9 @@ public class MazeSubSceneManager : MonoBehaviour
     private int _preloadedMaze = -1;
 
     private IEnumerator _cachedCoroutineToDestroy;
-    
+
+    public static event UnityAction OnMazeLoad;
+
     /// <summary>
     /// Performs any needed functionality for when the game starts
     /// </summary>
@@ -96,7 +99,9 @@ public class MazeSubSceneManager : MonoBehaviour
     public void LoadMazeAdditive(int mazeId)
     {
         _currentMaze = mazeId;
-        
+
+        OnMazeLoad.Invoke();
+
         int sceneId = _sceneManager.MazeAdditiveSceneIndices[mazeId];
         
         StartCoroutine(StartAsyncSceneLoadOperation(mazeId, sceneId));

--- a/Assets/Scripts/PlayerScripts/Harpoon/HarpoonGun.cs
+++ b/Assets/Scripts/PlayerScripts/Harpoon/HarpoonGun.cs
@@ -757,6 +757,7 @@ public class HarpoonGun : MonoBehaviour
         for (int i = 0; i < _harpoonPoolingAmount; i++)
         {
             ObjectPoolingParent.Instance.InitiallyAddObjectToPool(_harpoonSpearPool[i].gameObject);
+            _harpoonSpearPool[i].gameObject.SetActive(false);
         }
     }
 

--- a/Assets/Scripts/PlayerScripts/Harpoon/HarpoonGun.cs
+++ b/Assets/Scripts/PlayerScripts/Harpoon/HarpoonGun.cs
@@ -2,7 +2,7 @@
 // File Name :         HarpoonGun.cs
 // Author :            Tommy Roberts
 // Contributors:       Ryan Swanson, Adam Garwacki, Andrew Stapay, David Henvick, 
-//                     Miles Rogers, Nick Rice, Charlie Polonus
+//                     Miles Rogers, Nick Rice, Charlie Polonus, Jeremiah Peters
 // Creation Date :     9/22/2024
 //
 // Brief Description : Controls the basic shoot harpoon and retract functionality.
@@ -16,6 +16,7 @@ using Cinemachine;
 using Unity.VisualScripting;
 using PrimeTween;
 using FMOD.Studio;
+using UnityEngine.SceneManagement;
 using UnityEngine.Rendering.Universal;
 
 /// <summary>
@@ -200,6 +201,8 @@ public class HarpoonGun : MonoBehaviour
         CameraManager.Instance.GetOnCinematicStartEvent().AddListener(HideReticle);
         CameraManager.Instance.GetOnCinematicStartEvent().AddListener(ResetFocus);
         CameraManager.Instance.GetOnCinematicEndEvent().AddListener(ShowReticle);
+        
+        SceneManager.sceneLoaded += StartRepairHarpoons;
     }
 
     /// <summary>
@@ -215,6 +218,8 @@ public class HarpoonGun : MonoBehaviour
         CameraManager.Instance.GetOnCinematicStartEvent().RemoveListener(HideReticle);
         CameraManager.Instance.GetOnCinematicStartEvent().RemoveListener(ResetFocus);
         CameraManager.Instance.GetOnCinematicEndEvent().RemoveListener(ShowReticle);
+        
+        SceneManager.sceneLoaded -= StartRepairHarpoons;
     }
 
     /// <summary>
@@ -737,6 +742,38 @@ public class HarpoonGun : MonoBehaviour
             _harpoonSpearPool[i] = newestHarpoon;
             ObjectPoolingParent.Instance.InitiallyAddObjectToPool(newestHarpoon.gameObject);
             newestHarpoon.gameObject.SetActive(false);
+        }
+    }
+
+    /// <summary>
+    /// starts the RepairHarpoons coroutine
+    /// it won't let me start a coroutine directly from the scene loaded event, so i did this work around
+    /// </summary>
+    /// <param name="scene"></param>
+    /// <param name="mode"></param>
+    private void StartRepairHarpoons(Scene scene, LoadSceneMode mode)
+    {
+        StartCoroutine(RepairHarpoons());
+    }
+
+
+    /// <summary>
+    /// replaces any harpoons that got destroyed in scene transition
+    /// </summary>
+    private IEnumerator RepairHarpoons()
+    {
+        //wait for new scene to be fully loaded
+        yield return new WaitForSeconds(0.1f);
+
+        //check and fix each harpoon that needs fixed
+        for (int i = 0; i < _harpoonPoolingAmount; i++)
+        {
+            if (_harpoonSpearPool[i] == null)
+            {
+                _harpoonSpearPool[i] = Instantiate(_harpoonPrefab,
+                    _playerLookDirection.position, Quaternion.identity).GetComponent<HarpoonProjectileMovement>();
+                _harpoonSpearPool[i].gameObject.SetActive(false);
+            }
         }
     }
 

--- a/Assets/Scripts/PlayerScripts/Harpoon/HarpoonGun.cs
+++ b/Assets/Scripts/PlayerScripts/Harpoon/HarpoonGun.cs
@@ -201,8 +201,10 @@ public class HarpoonGun : MonoBehaviour
         CameraManager.Instance.GetOnCinematicStartEvent().AddListener(HideReticle);
         CameraManager.Instance.GetOnCinematicStartEvent().AddListener(ResetFocus);
         CameraManager.Instance.GetOnCinematicEndEvent().AddListener(ShowReticle);
-        
-        SceneManager.sceneLoaded += StartRepairHarpoons;
+
+        AframaxSceneManager.Instance.GetOnBeforeSceneChanged.AddListener(ReturnHarpoons);
+
+        MazeSubSceneManager.OnMazeLoad += ReturnHarpoons;
     }
 
     /// <summary>
@@ -218,8 +220,10 @@ public class HarpoonGun : MonoBehaviour
         CameraManager.Instance.GetOnCinematicStartEvent().RemoveListener(HideReticle);
         CameraManager.Instance.GetOnCinematicStartEvent().RemoveListener(ResetFocus);
         CameraManager.Instance.GetOnCinematicEndEvent().RemoveListener(ShowReticle);
-        
-        SceneManager.sceneLoaded -= StartRepairHarpoons;
+
+        AframaxSceneManager.Instance.GetOnBeforeSceneChanged.RemoveListener(ReturnHarpoons);
+
+        MazeSubSceneManager.OnMazeLoad -= ReturnHarpoons;
     }
 
     /// <summary>
@@ -746,34 +750,13 @@ public class HarpoonGun : MonoBehaviour
     }
 
     /// <summary>
-    /// starts the RepairHarpoons coroutine
-    /// it won't let me start a coroutine directly from the scene loaded event, so i did this work around
+    /// returns harpoons to object pooling when changing scenes
     /// </summary>
-    /// <param name="scene"></param>
-    /// <param name="mode"></param>
-    private void StartRepairHarpoons(Scene scene, LoadSceneMode mode)
+    private void ReturnHarpoons()
     {
-        StartCoroutine(RepairHarpoons());
-    }
-
-
-    /// <summary>
-    /// replaces any harpoons that got destroyed in scene transition
-    /// </summary>
-    private IEnumerator RepairHarpoons()
-    {
-        //wait for new scene to be fully loaded
-        yield return new WaitForSeconds(0.1f);
-
-        //check and fix each harpoon that needs fixed
         for (int i = 0; i < _harpoonPoolingAmount; i++)
         {
-            if (_harpoonSpearPool[i] == null)
-            {
-                _harpoonSpearPool[i] = Instantiate(_harpoonPrefab,
-                    _playerLookDirection.position, Quaternion.identity).GetComponent<HarpoonProjectileMovement>();
-                _harpoonSpearPool[i].gameObject.SetActive(false);
-            }
+            ObjectPoolingParent.Instance.InitiallyAddObjectToPool(_harpoonSpearPool[i].gameObject);
         }
     }
 

--- a/Assets/Scripts/PlayerScripts/Harpoon/HarpoonProjectileMovement.cs
+++ b/Assets/Scripts/PlayerScripts/Harpoon/HarpoonProjectileMovement.cs
@@ -1,7 +1,7 @@
 /*****************************************************************************
 // File Name :         HarpoonProjectileMovement.cs
 // Author :            Ryan Swanson
-// Contributors:       David Henvick, Alex Kalscheur
+// Contributors:       David Henvick, Alex Kalscheur, Jeremiah Peters
 // Creation Date :     10/28/2024
 //
 // Brief Description : Controls the movement of the harpoon projectile
@@ -102,6 +102,10 @@ public class HarpoonProjectileMovement : MonoBehaviour
     /// <param name="other"> The collider we contacted</param>
     public void ImpaleHarpoon(Collider other)
     {
+        //child the harpoon to whatever it hit
+        //now if that object moves, the harpoon will move with it
+        gameObject.transform.parent = other.gameObject.transform;
+        
         // Prevent the harpoon from impaling into an object while already impaled
         if (IsHit)
         {


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/browse/LV-2225

Harpoons now become children to whatever object they get lodged into, meaning if that object moves, the harpoon moves with it. Easiest to test with the door at the very start of the game.

As a consequence of this, the harpoons would no longer be considered dontdestroyonload, and they would be lost when unloading the scene with the parent object. Since the amount of harpoons is finite, this meant you would be unable to shoot that harpoon ever again. In order to fix this, I made a function that runs whenever a new scene is loaded that checks each of the harpoons and creates a new one if it is missing.