### PR TITLE
pg-eng-mouse-visability-during-controller-gameplay-LV-2218

### DIFF
--- a/Assets/Prefabs/Managers/UniversalManagers/MainUniversalManagers/UiManager.prefab
+++ b/Assets/Prefabs/Managers/UniversalManagers/MainUniversalManagers/UiManager.prefab
@@ -44,3 +44,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 47e50585b4c88e4479a54fbaaa0c4dec, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _shouldMouseAppearUsingController: 1

--- a/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/UiManager.cs
+++ b/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/UiManager.cs
@@ -113,7 +113,20 @@ public class UiManager : MainUniversalManagerFramework
     {
         _isUsingController = !_isUsingController;
         SaveManager.Instance.GetGameSaveData().IsUsingController = _isUsingController;
+        ToggleMouse();
         _onSwapInput?.Invoke();
+    }
+
+    private void ToggleMouse()
+    {
+        if (_isUsingController)
+        {
+            UnityEngine.Cursor.lockState = CursorLockMode.Locked;
+        }
+        else
+        {
+            UnityEngine.Cursor.lockState = CursorLockMode.None;
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/UiManager.cs
+++ b/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/UiManager.cs
@@ -36,6 +36,12 @@ public class UiManager : MainUniversalManagerFramework
         _playerInput = new PlayerInputMap();
         _backButtons.Clear();
         _previousUiSelections.Clear();
+
+        // Let's make sure that the mouse is hidden when you start the game again
+        if (_isUsingController)
+        {
+            UnityEngine.Cursor.lockState = CursorLockMode.Locked;
+        }
     }
     
     #region Back Button

--- a/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/UiManager.cs
+++ b/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/UiManager.cs
@@ -123,6 +123,9 @@ public class UiManager : MainUniversalManagerFramework
         _onSwapInput?.Invoke();
     }
 
+    /// <summary>
+    /// Toggles whether or not the mouse should be available based on when a controller is used
+    /// </summary>
     private void ToggleMouse()
     {
         if (_isUsingController)

--- a/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/UiManager.cs
+++ b/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/UiManager.cs
@@ -27,6 +27,8 @@ public class UiManager : MainUniversalManagerFramework
     public Stack<Button> _backButtons = new();
     private PlayerInputMap _playerInput;
 
+    [SerializeField] private bool _shouldMouseAppearUsingController;
+
     /// <summary>
     /// Makes the controller toggle save between game sessions
     /// </summary>
@@ -128,13 +130,16 @@ public class UiManager : MainUniversalManagerFramework
     /// </summary>
     private void ToggleMouse()
     {
-        if (_isUsingController)
+        if (!_shouldMouseAppearUsingController)
         {
-            UnityEngine.Cursor.lockState = CursorLockMode.Locked;
-        }
-        else
-        {
-            UnityEngine.Cursor.lockState = CursorLockMode.None;
+            if (_isUsingController)
+            {
+                UnityEngine.Cursor.lockState = CursorLockMode.Locked;
+            }
+            else
+            {
+                UnityEngine.Cursor.lockState = CursorLockMode.None;
+            }
         }
     }
 
@@ -163,6 +168,8 @@ public class UiManager : MainUniversalManagerFramework
     #region Getters
 
     public static bool IsUsingController => _isUsingController;
+
+    public bool ShouldMouseAppearUsingController => _shouldMouseAppearUsingController;
 
     public UnityEvent GetOnSwapInput => _onSwapInput;
 

--- a/Assets/Scripts/PlayerScripts/PlayerCameraController.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerCameraController.cs
@@ -480,7 +480,12 @@ public class PlayerCameraController : MonoBehaviour
             {
                 StopCoroutine(_cameraSpeedReturnCoroutine);
             }
-            UnityEngine.Cursor.lockState = CursorLockMode.None;
+
+            if (!UiManager.IsUsingController)
+            {
+                UnityEngine.Cursor.lockState = CursorLockMode.None;
+            }
+            
             SetCinemachineSpeed(0, 0);
         }
     }

--- a/Assets/Scripts/UI/SettingsPagesBehaviour.cs
+++ b/Assets/Scripts/UI/SettingsPagesBehaviour.cs
@@ -54,6 +54,10 @@ public class SettingsPagesBehaviour : MonoBehaviour
         _gameplayNavigation = _gameplayButton.navigation;
         _gameplayNavigation.mode = Navigation.Mode.Explicit; 
 
+        if (UiManager.Instance.ShouldMouseAppearUsingController)
+        {
+            UnityEngine.Cursor.lockState = CursorLockMode.None;
+        }
     }
 
     /// <summary>
@@ -85,12 +89,6 @@ public class SettingsPagesBehaviour : MonoBehaviour
                 _gameplayButton.colors = _notFocusedColors;
                 _gameplayNavigation.selectOnDown = _topAudioSlider;
                 _gameplayButton.navigation = _gameplayNavigation;
-
-                // REMOVE THIS WHEN RESOLUTION CAN BE ACCESSED BY CONTROLLER
-                if (UiManager.IsUsingController)
-                {
-                    UnityEngine.Cursor.lockState = CursorLockMode.Locked;
-                }
                 break;
             case 1:
                 //video settings button pressed
@@ -106,9 +104,6 @@ public class SettingsPagesBehaviour : MonoBehaviour
                 _gameplayButton.colors = _notFocusedColors;
                 _gameplayNavigation.selectOnDown = _topVideoToggle;
                 _gameplayButton.navigation = _gameplayNavigation;
-
-                // REMOVE THIS WHEN RESOLUTION CAN BE ACCESSED BY CONTROLLER
-                UnityEngine.Cursor.lockState = CursorLockMode.None;
                 break;
             case 2:
                 //gameplay settings button pressed
@@ -123,12 +118,6 @@ public class SettingsPagesBehaviour : MonoBehaviour
                 _gameplayButton.colors = _yesFocusedColors;
                 _gameplayNavigation.selectOnDown = _topGameplayToggle;
                 _gameplayButton.navigation = _gameplayNavigation;
-
-                // REMOVE THIS WHEN RESOLUTION CAN BE ACCESSED BY CONTROLLER
-                if (UiManager.IsUsingController)
-                {
-                    UnityEngine.Cursor.lockState = CursorLockMode.Locked;
-                }
                 break;
             default:
                 //this should not happen

--- a/Assets/Scripts/UI/SettingsPagesBehaviour.cs
+++ b/Assets/Scripts/UI/SettingsPagesBehaviour.cs
@@ -85,6 +85,12 @@ public class SettingsPagesBehaviour : MonoBehaviour
                 _gameplayButton.colors = _notFocusedColors;
                 _gameplayNavigation.selectOnDown = _topAudioSlider;
                 _gameplayButton.navigation = _gameplayNavigation;
+
+                // REMOVE THIS WHEN RESOLUTION CAN BE ACCESSED BY CONTROLLER
+                if (UiManager.IsUsingController)
+                {
+                    UnityEngine.Cursor.lockState = CursorLockMode.Locked;
+                }
                 break;
             case 1:
                 //video settings button pressed
@@ -100,6 +106,9 @@ public class SettingsPagesBehaviour : MonoBehaviour
                 _gameplayButton.colors = _notFocusedColors;
                 _gameplayNavigation.selectOnDown = _topVideoToggle;
                 _gameplayButton.navigation = _gameplayNavigation;
+
+                // REMOVE THIS WHEN RESOLUTION CAN BE ACCESSED BY CONTROLLER
+                UnityEngine.Cursor.lockState = CursorLockMode.None;
                 break;
             case 2:
                 //gameplay settings button pressed
@@ -114,6 +123,12 @@ public class SettingsPagesBehaviour : MonoBehaviour
                 _gameplayButton.colors = _yesFocusedColors;
                 _gameplayNavigation.selectOnDown = _topGameplayToggle;
                 _gameplayButton.navigation = _gameplayNavigation;
+
+                // REMOVE THIS WHEN RESOLUTION CAN BE ACCESSED BY CONTROLLER
+                if (UiManager.IsUsingController)
+                {
+                    UnityEngine.Cursor.lockState = CursorLockMode.Locked;
+                }
                 break;
             default:
                 //this should not happen


### PR DESCRIPTION
Mouse now disappears during controller gameplay for good! I kinda thought "why don't we just get rid of the mouse right away when we toggle the controller since the keyboard controls still work no matter the setting?" so this is the result of that. The original task was to just keep it gone when using controller during cutscenes and note reading. Hopefully everything still works out.

Jira Task: https://bradleycapstone.atlassian.net/browse/LV-2218?atlOrigin=eyJpIjoiNGExMTc0ODJiZjg5NGM5OGJjNTBhZDhhM2UxM2RjNjUiLCJwIjoiaiJ9

Code Review Time: <2 minutes
In-Engine Review Time: <10 minutes (play through the game with both keyboard and controller and see if everything is fine in terms of when the mouse appears)