### PR TITLE
pg-eng-Firing-animation-playing-at-incorrect-timing-LV-2219

### DIFF
--- a/Assets/Prefabs/PlayerPrefabs/Harpoon.prefab
+++ b/Assets/Prefabs/PlayerPrefabs/Harpoon.prefab
@@ -335,7 +335,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _fireSpeed: 50
   _maxDistance: 40
-  _reloadTime: 5
+  _reloadTime: 6
   _doesHarpoonRemainInHitObject: 1
   _harpoonPrefab: {fileID: 8430130115990038482, guid: 84f2eb355931fc747b5e9353cbff9bbb,
     type: 3}

--- a/Assets/Scripts/PlayerScripts/Harpoon/HarpoonAnimationManager.cs
+++ b/Assets/Scripts/PlayerScripts/Harpoon/HarpoonAnimationManager.cs
@@ -136,6 +136,7 @@ public class HarpoonAnimationManager : MonoBehaviour
     private void ReloadHarpoonAnimation()
     {
         _animator.SetTrigger(Animator.StringToHash(_RELOAD_READY_ANIM));
+        _animator.ResetTrigger(Animator.StringToHash(_FIRE_ANIM));
     }
     
     /// <summary>

--- a/Assets/Scripts/PlayerScripts/Harpoon/HarpoonAnimationManager.cs
+++ b/Assets/Scripts/PlayerScripts/Harpoon/HarpoonAnimationManager.cs
@@ -99,8 +99,8 @@ public class HarpoonAnimationManager : MonoBehaviour
     /// </summary>
     private void StartFocusingAnimation()
     {
-        
         _animator.SetBool(Animator.StringToHash(_FOCUS_ANIM), true);
+        _animator.ResetTrigger(Animator.StringToHash(_FIRE_ANIM));
     }
 
     /// <summary>
@@ -136,7 +136,6 @@ public class HarpoonAnimationManager : MonoBehaviour
     private void ReloadHarpoonAnimation()
     {
         _animator.SetTrigger(Animator.StringToHash(_RELOAD_READY_ANIM));
-        _animator.ResetTrigger(Animator.StringToHash(_FIRE_ANIM));
     }
     
     /// <summary>


### PR DESCRIPTION
Literally a one line fix. I just had to put an extra defense on the reloading animation trigger to make sure the shooting trigger wasn't still active.

Jira Task: https://bradleycapstone.atlassian.net/browse/LV-2219?atlOrigin=eyJpIjoiNzU0NTA4YWRlNTRjNDRhYzk5MTkwNDhhNjE2MWUwYzMiLCJwIjoiaiJ9

Code Review Time: <1 minute
In-Engine Review Time: <2 minutes (the idea is to left click on the frame immediately after you start to hold right click. the animations should play relatively normally considering the speed of your inputs)