### PR TITLE
super simple fix

### DIFF
--- a/Assets/Prefabs/PlayerPrefabs/HarpoonProjectile.prefab
+++ b/Assets/Prefabs/PlayerPrefabs/HarpoonProjectile.prefab
@@ -57,8 +57,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 0.03, y: 0.03, z: 2}
-  m_Center: {x: 0, y: 0, z: -0.28}
+  m_Size: {x: 0.03, y: 0.03, z: 1.6136591}
+  m_Center: {x: 0, y: 0, z: -0.08682957}
 --- !u!54 &112382357724614757
 Rigidbody:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Made the harpoon projectile collider a little shorter than it needs to be so it didn't collide with the wall behind the player when they shoot. 

Play the game and shoot the harpoon gun with your back to the wall, it should fire normally now. If it doesn't, lmk.

Jira Task: https://bradleycapstone.atlassian.net/browse/LV-2292?atlOrigin=eyJpIjoiYmRjYzMzNTNmM2Y5NDYwMTg5NWQyM2Y3MWQ4ZGM4ZjgiLCJwIjoiaiJ9