### PR TITLE
pg-eng-Fix-Harpoons-Floating-In-Air-LV-2348

### DIFF
--- a/Assets/Art/3D/Boss/BossPrefabs/Stem(wahckaMole2).prefab
+++ b/Assets/Art/3D/Boss/BossPrefabs/Stem(wahckaMole2).prefab
@@ -745,7 +745,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5268b2c91a0bee146a8862a8ded302c2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _delayFirstSpawn: 1
+  _delayFirstSpawn: 0
   _spawnInterval: 1
   _retractOnAllWeakPointsDestroyed: 1
   _weakPointPrefab: {fileID: 7717971156621110341, guid: 1ca29d51decce974db16269dd060eee0,
@@ -2184,6 +2184,7 @@ Transform:
   - {fileID: 5932457000614412714}
   - {fileID: 3283541621687039367}
   - {fileID: 4462097558539267528}
+  - {fileID: 2759935385881032462}
   m_Father: {fileID: 6434425521765479052}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6995502550590712007
@@ -2813,6 +2814,8 @@ MonoBehaviour:
   _appearSpeed: 1
   _appearDistance: 0
   _isAppeared: 0
+  _hitboxDelay: 1
+  _hitbox: {fileID: 1017190038065120841}
   _whackAMoleAttackPath: {fileID: 0}
   _whackAMoleAttackSpeed: 3
   _whackAMoleAttackDistance: 0
@@ -3142,3 +3145,56 @@ MonoBehaviour:
     m_DampPosition: 0.391
     m_DampRotation: 0.496
     m_MaintainAim: 0
+--- !u!1 &9195494941573162427
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2759935385881032462}
+  - component: {fileID: 1017190038065120841}
+  m_Layer: 8
+  m_Name: DamageHitbox
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2759935385881032462
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9195494941573162427}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.38}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8553731799398769672}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1017190038065120841
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9195494941573162427}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Art/3D/Boss/BossPrefabs/WeakPoints/WeakPoint.prefab
+++ b/Assets/Art/3D/Boss/BossPrefabs/WeakPoints/WeakPoint.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: -27814061537787058}
   m_Layer: 8
   m_Name: WeakPoint
-  m_TagString: Enemy
+  m_TagString: Weak Spot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Art/3D/Boss/BossScripts/Attacks/ProceduralAttack/ProceduralVine.cs
+++ b/Assets/Art/3D/Boss/BossScripts/Attacks/ProceduralAttack/ProceduralVine.cs
@@ -55,6 +55,9 @@ public class ProceduralVine : MonoBehaviour
     [SerializeField] private float _appearSpeed = 5f; // Speed of movement
     [SerializeField] private float _appearDistance = 0;
     [SerializeField] private bool _isAppeared = false;
+    [SerializeField] private float _hitboxDelay;
+    [SerializeField] private BoxCollider _hitbox;
+    private WaitForSeconds _hitboxWait;
 
     [Header("WAttack Stuff")]
     [SerializeField] private PathCreator _whackAMoleAttackPath; // The target to move toward
@@ -99,6 +102,13 @@ public class ProceduralVine : MonoBehaviour
         {
             _animator = GetComponent<Animator>();
         }
+
+        if (_hitboxWait.IsUnityNull())
+        {
+            _hitboxWait = new WaitForSeconds(_hitboxDelay);
+        }
+
+        StartCoroutine(HitboxSpawnDelay());
     }
 
     /// <summary>
@@ -178,6 +188,16 @@ public class ProceduralVine : MonoBehaviour
             }*/
         }
         
+    }
+
+    /// <summary>
+    /// Creates a delay for the hitbox to deal damage
+    /// </summary>
+    /// <returns></returns>
+    private IEnumerator HitboxSpawnDelay()
+    {
+        yield return new WaitForSeconds(_hitboxDelay);
+        _hitbox.enabled = true;
     }
 
     /// <summary>

--- a/Assets/Prefabs/PlayerPrefabs/Harpoon.prefab
+++ b/Assets/Prefabs/PlayerPrefabs/Harpoon.prefab
@@ -373,7 +373,7 @@ MonoBehaviour:
   _harpoonOnGun: {fileID: 2178814002120738897}
   _excludeLayers:
     serializedVersion: 2
-    m_Bits: 9
+    m_Bits: 265
   _harpoonShoot: {fileID: -5070425021129914811, guid: a9035e5084fec0e4a81fdaa78201ec2c,
     type: 3}
   _harpoonReload: {fileID: 2044851616179912923, guid: a9035e5084fec0e4a81fdaa78201ec2c,

--- a/Assets/Scripts/PlayerScripts/Harpoon/HarpoonDamage.cs
+++ b/Assets/Scripts/PlayerScripts/Harpoon/HarpoonDamage.cs
@@ -20,7 +20,7 @@ public class HarpoonDamage : BaseDamage
     public override void ApplyDamage(GameObject damageRecipient)
     {
         // Avoids damaging the player
-        if (damageRecipient.TryGetComponent<PlayerHealth>(out PlayerHealth playerHealth) || !damageRecipient.CompareTag("Enemy"))
+        if (damageRecipient.TryGetComponent<PlayerHealth>(out PlayerHealth playerHealth) || !damageRecipient.CompareTag("Weak Spot"))
         {
             return;
         }


### PR DESCRIPTION
https://bradleycapstone.atlassian.net/jira/software/projects/LV/boards/32/backlog?assignee=6318bb796856bdd60aa045de&selectedIssue=LV-2348

Ended up finding and fixing a separate issue in this one as well
For the main issue on rare occasions the harpoons would stick in the air when hitting enemies. This is really hard to replicate and I didn't have an effective method other than just constantly shooting monsters
For the second issue I discovered that monsters don't actually have a hitbox for a second after spawning. This means 2 things, for one the monster can't deal damage for 1 second, which is a good thing, but it also can't take damage for 1 second. I split it into 2 separate hitboxes, one for dealing damage and one for taking it. It now spawns the hitbox for taking damage instantly and enables the second after a delay.

How to test: Try shooting monsters to see if the harpoon sticks in air on hitting them.
Try shooting monsters within a second of them spawning, they should die properly now
Try taking damage from a monster as soon as it spawns, it should still have a 1 second delay before dealing damage

Code Review Estimation: <3 minutes
In Engine Review Estimation: <10 minutes