### PR TITLE
pg-eng-fix-credits-scroll

### DIFF
--- a/Assets/Scenes/BuildScenes/Submenus/CreditsScreen.unity
+++ b/Assets/Scenes/BuildScenes/Submenus/CreditsScreen.unity
@@ -13040,9 +13040,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _movingDestination: {fileID: 615320896}
-  _screenScrollSpeed: 200
+  _screenScrollSpeed: 120
   _scrollWaitTime: 2
-  _scrollEndWaitTime: 1
   _sceneCanvas: {fileID: 814277661}
 --- !u!114 &1668760147
 MonoBehaviour:

--- a/Assets/Scenes/BuildScenes/Submenus/CreditsScreen.unity
+++ b/Assets/Scenes/BuildScenes/Submenus/CreditsScreen.unity
@@ -6462,8 +6462,8 @@ RectTransform:
   m_GameObject: {fileID: 773188301}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 814277662}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -6826,7 +6826,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!223 &814277661
 Canvas:
   m_ObjectHideFlags: 0
@@ -6836,7 +6836,7 @@ Canvas:
   m_GameObject: {fileID: 814277658}
   m_Enabled: 1
   serializedVersion: 3
-  m_RenderMode: 0
+  m_RenderMode: 2
   m_Camera: {fileID: 0}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
@@ -6859,7 +6859,7 @@ RectTransform:
   m_GameObject: {fileID: 814277658}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.4342593, y: 0.4342593, z: 0.4342593}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 773188302}
@@ -6868,9 +6868,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 417, y: 234.5}
+  m_SizeDelta: {x: 1920.5116, y: 1079.9999}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &816998473
 GameObject:
   m_ObjectHideFlags: 0
@@ -12838,8 +12838,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _movingDestination: {fileID: 615320896}
-  _screenScrollSpeed: 250
+  _screenScrollSpeed: 200
   _scrollWaitTime: 2
+  _scrollEndWaitTime: 1
   _sceneCanvas: {fileID: 814277661}
 --- !u!1 &1673243805
 GameObject:
@@ -16428,7 +16429,7 @@ Transform:
   m_GameObject: {fileID: 2083395148}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 425.2, y: 237.1, z: -302.9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scenes/BuildScenes/Submenus/CreditsScreen.unity
+++ b/Assets/Scenes/BuildScenes/Submenus/CreditsScreen.unity
@@ -5691,6 +5691,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 587351124}
   m_CullTransparentMesh: 1
+--- !u!224 &592992299 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+    type: 3}
+  m_PrefabInstance: {fileID: 652325796}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &592992302 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 7781006255243844553, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+    type: 3}
+  m_PrefabInstance: {fileID: 652325796}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &615320895
 GameObject:
   m_ObjectHideFlags: 0
@@ -5921,6 +5933,194 @@ Transform:
   - {fileID: 1485195024}
   m_Father: {fileID: 1682015988}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &652325796
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 814277662}
+    m_Modifications:
+    - target: {fileID: 1784452198889138800, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_TargetGraphic
+      value: 
+      objectReference: {fileID: 1669395889}
+    - target: {fileID: 1784452198889138800, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1784452198889138800, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: LoadNextScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 1784452198889138800, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: CinematicManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1784452198889138800, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2574426269970197711, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 37888.785
+      objectReference: {fileID: 0}
+    - target: {fileID: 2574426269970197711, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -1387.2234
+      objectReference: {fileID: 0}
+    - target: {fileID: 2762990375454679275, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_text
+      value: Skip
+      objectReference: {fileID: 0}
+    - target: {fileID: 4266977005618925551, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_Name
+      value: Escape back
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.000017166138
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -46.100586
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 35.000885
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6196699160558198240, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_Color.a
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6508502495816008927, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_text
+      value: Skip
+      objectReference: {fileID: 0}
+    - target: {fileID: 6508502495816008927, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_fontColor.a
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6508502495816008927, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 16777215
+      objectReference: {fileID: 0}
+    - target: {fileID: 7763898667118207667, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_Color.a
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8064115918933602861, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -43
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f05c39bdca33cdf4f92f39cb8fd42ad7, type: 3}
 --- !u!1 &667819461
 GameObject:
   m_ObjectHideFlags: 0
@@ -6864,7 +7064,7 @@ RectTransform:
   m_Children:
   - {fileID: 773188302}
   - {fileID: 1668760145}
-  - {fileID: 1938957591}
+  - {fileID: 592992299}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -12856,7 +13056,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f939fe2da09f42449ac93937f7da5494, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _skipPromptTextAnimator: {fileID: 1938957593}
+  _skipPromptTextAnimator: {fileID: 592992302}
   _skipPromptDuration: 1.5
   _onSkip:
     m_PersistentCalls:
@@ -12873,6 +13073,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &1669395889 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2762990375454679275, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+    type: 3}
+  m_PrefabInstance: {fileID: 652325796}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1673243805
 GameObject:
   m_ObjectHideFlags: 0
@@ -14938,253 +15150,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1920622928}
   m_CullTransparentMesh: 1
---- !u!1001 &1938957590
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 814277662}
-    m_Modifications:
-    - target: {fileID: 1784452198889138800, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_TargetGraphic
-      value: 
-      objectReference: {fileID: 1938957592}
-    - target: {fileID: 1784452198889138800, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1784452198889138800, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
-      value: 
-      objectReference: {fileID: 1668760146}
-    - target: {fileID: 1784452198889138800, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: ReturnToMainMenu
-      objectReference: {fileID: 0}
-    - target: {fileID: 1784452198889138800, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: CreditsScrolling, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 1784452198889138800, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 2134323405058163126, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_Color.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2574426269970197711, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 37821.523
-      objectReference: {fileID: 0}
-    - target: {fileID: 2574426269970197711, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -839.2059
-      objectReference: {fileID: 0}
-    - target: {fileID: 2762990375454679275, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_text
-      value: Skip
-      objectReference: {fileID: 0}
-    - target: {fileID: 2762990375454679275, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_fontColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2762990375454679275, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 4266977005618925551, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_Name
-      value: Escape back
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 50
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.000017166138
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -46.100586
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 35.000977
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6196699160558198240, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_Color.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6422530754474443586, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 14033.579
-      objectReference: {fileID: 0}
-    - target: {fileID: 6422530754474443586, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 63.901
-      objectReference: {fileID: 0}
-    - target: {fileID: 6422530754474443586, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -832.7969
-      objectReference: {fileID: 0}
-    - target: {fileID: 6508502495816008927, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_text
-      value: Skip
-      objectReference: {fileID: 0}
-    - target: {fileID: 6508502495816008927, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_fontColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6508502495816008927, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 7763898667118207667, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_Color.a
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8064115918933602861, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -43
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f05c39bdca33cdf4f92f39cb8fd42ad7, type: 3}
---- !u!224 &1938957591 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4715139476089034394, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-    type: 3}
-  m_PrefabInstance: {fileID: 1938957590}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1938957592 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2762990375454679275, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-    type: 3}
-  m_PrefabInstance: {fileID: 1938957590}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!95 &1938957593 stripped
-Animator:
-  m_CorrespondingSourceObject: {fileID: 7781006255243844553, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
-    type: 3}
-  m_PrefabInstance: {fileID: 1938957590}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1942321528
 GameObject:
   m_ObjectHideFlags: 0
@@ -16707,7 +16672,7 @@ Transform:
   m_GameObject: {fileID: 2083395148}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 425.2, y: 237.1, z: -302.9}
+  m_LocalPosition: {x: 425.2, y: 237.1, z: -414}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scenes/BuildScenes/Submenus/CreditsScreen.unity
+++ b/Assets/Scenes/BuildScenes/Submenus/CreditsScreen.unity
@@ -14976,6 +14976,11 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
+    - target: {fileID: 2134323405058163126, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_Color.a
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2574426269970197711, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
         type: 3}
       propertyPath: m_SizeDelta.x
@@ -14990,6 +14995,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_text
       value: Skip
+      objectReference: {fileID: 0}
+    - target: {fileID: 2762990375454679275, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_fontColor.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2762990375454679275, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
+        type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967295
       objectReference: {fileID: 0}
     - target: {fileID: 4266977005618925551, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
         type: 3}
@@ -15099,7 +15114,7 @@ PrefabInstance:
     - target: {fileID: 6196699160558198240, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
         type: 3}
       propertyPath: m_Color.a
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6422530754474443586, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
         type: 3}
@@ -15124,12 +15139,12 @@ PrefabInstance:
     - target: {fileID: 6508502495816008927, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
         type: 3}
       propertyPath: m_fontColor.a
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6508502495816008927, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
         type: 3}
       propertyPath: m_fontColor32.rgba
-      value: 16777215
+      value: 4294967295
       objectReference: {fileID: 0}
     - target: {fileID: 7763898667118207667, guid: f05c39bdca33cdf4f92f39cb8fd42ad7,
         type: 3}

--- a/Assets/Scripts/MenuFunctionality/CreditsScrolling.cs
+++ b/Assets/Scripts/MenuFunctionality/CreditsScrolling.cs
@@ -27,7 +27,7 @@ public class CreditsScrolling : MonoBehaviour
     private bool _hasScrollingStarted = false;
 
     /// <summary>
-    /// Performs needed set up
+    /// Performs all functionality needed when this object is created
     /// </summary>
     private void Awake()
     {
@@ -76,7 +76,14 @@ public class CreditsScrolling : MonoBehaviour
         {
             SteamAchievements.Instance.CompleteCredits();
         }
-        AframaxSceneManager.Instance.StartAsyncSceneLoadViaID(AframaxSceneManager.Instance.MainMenuSceneIndex, 0);
+        ReturnToMainMenu();
     }
 
+    /// <summary>
+    /// Returns the player to the main menu
+    /// </summary>
+    public void ReturnToMainMenu()
+    {
+        AframaxSceneManager.Instance.StartAsyncSceneLoadViaID(AframaxSceneManager.Instance.MainMenuSceneIndex, 0);
+    }
 }

--- a/Assets/Scripts/MenuFunctionality/CreditsScrolling.cs
+++ b/Assets/Scripts/MenuFunctionality/CreditsScrolling.cs
@@ -20,11 +20,15 @@ public class CreditsScrolling : MonoBehaviour
 
     [SerializeField] private float _screenScrollSpeed;
     [SerializeField] private float _scrollWaitTime;
+    [SerializeField] private float _scrollEndWaitTime;
 
     [SerializeField] private Canvas _sceneCanvas;
 
     private bool _hasScrollingStarted = false;
 
+    /// <summary>
+    /// Performs needed set up
+    /// </summary>
     private void Awake()
     {
         if (_screenScrollSpeed == 0)
@@ -32,34 +36,46 @@ public class CreditsScrolling : MonoBehaviour
             Debug.LogWarning("scroll speed is set to zero, now it won't scroll, please fix that, thanks");
         }
 
-        StartCoroutine(ScrollingScreen(_movingDestination.position, _screenScrollSpeed, _scrollWaitTime));
+        StartScreenScroll();
+    }
+
+    /// <summary>
+    /// Starts the coroutine for scrolling the screen
+    /// </summary>
+    private void StartScreenScroll()
+    {
+        if (!_hasScrollingStarted)
+        {
+            _hasScrollingStarted = true;
+            StartCoroutine(ScrollingScreen(_movingDestination.position));
+        }
     }
 
     /// <summary>
     /// moves the ui up to simulate the camera moving down
     /// </summary>
-    /// <param name="destination"></param> designated movement destination
+    /// <param name="destination"> designated movement destination</param>
     /// <returns></returns>
-    private IEnumerator ScrollingScreen(Vector3 destination, float scrollSpeed, float scrollWaitTime)
+    private IEnumerator ScrollingScreen(Vector3 destination)
     {
-        yield return new WaitForSeconds(scrollWaitTime);
-
-        if (!_hasScrollingStarted)
+        yield return new WaitForSeconds(_scrollWaitTime);
+        
+        while (transform.position.y < destination.y)
         {
-            _hasScrollingStarted = true;
-            while (transform.position != destination)
-            {
-                transform.position = Vector3.MoveTowards(
-                    transform.position, new Vector3(transform.position.x, destination.y, transform.position.z),
-                    scrollSpeed * Time.deltaTime);
+            transform.position = Vector3.MoveTowards(
+                transform.position, new Vector3(transform.position.x, destination.y, transform.position.z),
+                _screenScrollSpeed * Time.deltaTime);
 
-                yield return null;
-            }
+            yield return null;
+            
         }
+        yield return new WaitForSeconds(_scrollEndWaitTime);
 
         // Once credits are over, loads the main menu
-        if(SteamManager.Initialized)
-        {SteamAchievements.Instance.CompleteCredits();}
+        if (SteamManager.Initialized)
+        {
+            SteamAchievements.Instance.CompleteCredits();
+        }
         AframaxSceneManager.Instance.StartAsyncSceneLoadViaID(AframaxSceneManager.Instance.MainMenuSceneIndex, 0);
     }
 


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/16URqM0YXxcVfVZ6MlO4QJtvad7bngXEr7y3WLCQJBXY/edit?gid=387920552#gid=387920552

The credits should no longer be able to get stuck and not complete. Also while I was at it I fixed the issue of the screen scroll speed being depended on resolution. I would like someone on the UI/UX team to verify this is as it should be and is scaling correctly depending on resolution.

How to test: Play through the credits multiple times to be sure it never gets stuck (Best way to replicate this is to change the size of the game view while the credits were scrolling), to make sure that the scroll speed is consistent across resolutions, and to make sure that the screen scaling didn't get messed up in the process.

Code Review Estimation: <6 minutes
In Engine Review Estimation: <8 minutes