### PR TITLE
pg-eng-free-mouse-bug

### DIFF
--- a/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/UiManager.cs
+++ b/Assets/Scripts/Managers/UniversalManagers/MainUniversalManagers/UiManager.cs
@@ -160,15 +160,18 @@ public class UiManager : MainUniversalManagerFramework
     /// <param name="hasAudio">Useless</param>
     private void ToggleMouse(bool isPaused, bool hasAudio)
     {
-        if (isPaused && !_isUsingController)
+        if (!_isUsingController)
         {
-            Cursor.lockState = CursorLockMode.None;
-            Cursor.visible = true;
-        }
-        else if (!isPaused && !_isUsingController)
-        {
-            Cursor.lockState = CursorLockMode.None;
-            Cursor.visible = false;
+            if (isPaused)
+            {
+                Cursor.lockState = CursorLockMode.None;
+                Cursor.visible = true;
+            }
+            else
+            {
+                Cursor.lockState = CursorLockMode.Locked;
+                Cursor.visible = false;
+            }
         }
     }
     


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/16URqM0YXxcVfVZ6MlO4QJtvad7bngXEr7y3WLCQJBXY/edit?gid=387920552#gid=387920552

Something was set to CursorLockMode.none when it shouldn't have been. Also I made an if statement slightly more efficient.

How to test: Play the game in Windowed mode in a build and/or in editor (It's technically in windowed mode), and try to move your mouse outside of the window when in gameplay and not paused. The mouse should not longer be able to escape (I trapped the little rascal). Ensure that the mouse isn't visible/invisible or locked/unlocked in some situation it shouldn't be.

In Engine Review Estimation: <10 if you are thorough about regression testing that nothing broke, but would be less otherwise