### PR TITLE
monster jitter bug

### DIFF
--- a/Assets/Art/3D/Boss/BossScripts/Attacks/ProceduralAttack/WhackAMole.cs
+++ b/Assets/Art/3D/Boss/BossScripts/Attacks/ProceduralAttack/WhackAMole.cs
@@ -127,6 +127,7 @@ public class WhackAMole : MonoBehaviour
     public void MonsterKilled()
     {
         CanAttack = false;
+        _currentActiveVine.transform.SetParent(null);
         StartCoroutine(HideHoleDecals());
     }
 


### PR DESCRIPTION
This bug was very annoying and took a while to fix but it was a single line that was needed. I'm putting this in a PR as I want a second set of eyes to look at the monster to ensure its working properly and that no new issues were created. If you want to try to replicate the monster jitter bug I found the most reliable way was to shoot the monster right as it opens its mouth a second time and stand somewhat close though it is still inconsistent. Hopefully it should be gone, but you can check develop if you want to see the issue. Just shoot a bunch of monsters and see if things are all working.